### PR TITLE
Bump mockito-core to the latest version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>2.8.47</version>
+            <version>2.22.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
According to `mvn versions:display-dependency-updates`, the following new versions for dependencies are found.

```
[INFO] The following dependencies in Dependencies have newer versions:
[INFO]   com.fasterxml.jackson.dataformat:jackson-dataformat-csv ...
[INFO]                                                           2.9.4 -> 2.9.6
[INFO]   org.apache.kafka:connect-api .......................... 1.1.0 -> 2.0.0
[INFO]   org.apache.kafka:connect-json ......................... 1.1.0 -> 2.0.0
[INFO]   org.apache.kafka:connect-runtime ...................... 1.1.0 -> 2.0.0
[INFO]   org.mockito:mockito-core ............................ 2.8.47 -> 2.21.0
```

Undoubtedly, we should not upgrade kafka's major version without necessary preparations and verifications. Apart from that, it may be possible to upgrade the patch versions for the rest. I've ran `mvn test` and confirmed all the tests succeed with the updated dependencies.

* Code diff for jackson-dataformat-csv
  * https://github.com/FasterXML/jackson-dataformats-text/compare/jackson-dataformats-text-2.9.4...jackson-dataformats-text-2.9.6

If you have the right time to upgrade them, feel free to close this PR or leave it for a while. 