### PR TITLE
Isolate MirusSourceTask consumer shutdown logic

### DIFF
--- a/src/main/java/com/salesforce/mirus/MirusSourceTask.java
+++ b/src/main/java/com/salesforce/mirus/MirusSourceTask.java
@@ -111,9 +111,8 @@ public class MirusSourceTask extends SourceTask {
     }
   }
 
-  protected void closeConsumer() {
-    // We are shutting down!
-    logger.debug("Closing consumer");
+  protected void shutDownTask() {
+    logger.debug("Task shutting down");
     consumer.close();
   }
 
@@ -171,7 +170,7 @@ public class MirusSourceTask extends SourceTask {
       if (!shutDown.get()) throw e;
     }
 
-    closeConsumer();
+    shutDownTask();
     return Collections.emptyList();
   }
 

--- a/src/main/java/com/salesforce/mirus/MirusSourceTask.java
+++ b/src/main/java/com/salesforce/mirus/MirusSourceTask.java
@@ -57,8 +57,9 @@ public class MirusSourceTask extends SourceTask {
   private String destinationTopicNamePrefix;
   private String destinationTopicNameSuffix;
   private Consumer<byte[], byte[]> consumer;
-  private AtomicBoolean shutDown = new AtomicBoolean(false);
   private boolean enablePartitionMatching = false;
+
+  protected AtomicBoolean shutDown = new AtomicBoolean(false);
 
   @SuppressWarnings("unused")
   public MirusSourceTask() {
@@ -108,6 +109,12 @@ public class MirusSourceTask extends SourceTask {
       shutDown.set(true);
       consumer.wakeup();
     }
+  }
+
+  protected void closeConsumer() {
+    // We are shutting down!
+    logger.debug("Closing consumer");
+    consumer.close();
   }
 
   private void seekToOffsets(List<TopicPartition> partitionIds) {
@@ -164,9 +171,7 @@ public class MirusSourceTask extends SourceTask {
       if (!shutDown.get()) throw e;
     }
 
-    // We are shutting down!
-    logger.debug("Closing consumer");
-    consumer.close();
+    closeConsumer();
     return Collections.emptyList();
   }
 


### PR DESCRIPTION
Allow consumer shutdown logic to be accessible to
classes that inherit this class. Also pull logic out
into a separate class to decouple it from the poll() method.