### PR TITLE
Deprecate com.salesforce.mirus.ByteArrayConverter

### DIFF
--- a/config/quickstart-worker.properties
+++ b/config/quickstart-worker.properties
@@ -8,8 +8,8 @@
 # Kafka broker bootstrap server - this is Source cluster
 bootstrap.servers=localhost:9092
 group.id=mirus-quickstart
-key.converter=com.salesforce.mirus.ByteArrayConverter
-value.converter=com.salesforce.mirus.ByteArrayConverter
+key.converter=org.apache.kafka.connect.converters.ByteArrayConverter
+value.converter=org.apache.kafka.connect.converters.ByteArrayConverter
 header.converter=org.apache.kafka.connect.converters.ByteArrayConverter
 key.converter.schemas.enable=false
 value.converter.schemas.enable=false

--- a/src/main/java/com/salesforce/mirus/ByteArrayConverter.java
+++ b/src/main/java/com/salesforce/mirus/ByteArrayConverter.java
@@ -13,7 +13,12 @@ import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaAndValue;
 import org.apache.kafka.connect.storage.Converter;
 
-/** This converter passes binary byte array data through unmodified. */
+/**
+ * This converter passes binary byte array data through unmodified.
+ *
+ * @deprecated Please use {@link org.apache.kafka.connect.converters.ByteArrayConverter}
+ */
+@Deprecated
 public class ByteArrayConverter implements Converter {
 
   @Override


### PR DESCRIPTION
We should now be using org.apache.kafka.connect.converters.ByteArrayConverter

See https://github.com/salesforce/mirus/issues/10