### PR TITLE
Handle tombstone records in offset tool

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.salesforce.mirus</groupId>
     <artifactId>mirus</artifactId>
-    <version>0.0.13-SNAPSHOT</version>
+    <version>0.0.14-SNAPSHOT</version>
 
     <name>Mirus</name>
     <description>Apache Kafka data replication tool based on Kafka Connect</description>

--- a/src/main/java/com/salesforce/mirus/MirusSourceTask.java
+++ b/src/main/java/com/salesforce/mirus/MirusSourceTask.java
@@ -8,7 +8,6 @@
 
 package com.salesforce.mirus;
 
-import com.google.common.collect.ImmutableMap;
 import com.salesforce.mirus.config.TaskConfig;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -70,10 +69,11 @@ public class MirusSourceTask extends SourceTask {
     this.consumerFactory = consumerFactory;
   }
 
-  public static Map<String, Long> offsetMap(long offset) {
-    return ImmutableMap.of(KEY_OFFSET, offset);
+  public static Map<String, Long> offsetMap(Long offset) {
+    return Collections.singletonMap(KEY_OFFSET, offset);
   }
 
+  @Override
   public String version() {
     return new MirusSourceConnector().version();
   }
@@ -148,8 +148,11 @@ public class MirusSourceTask extends SourceTask {
             }
             return;
           }
-          long lastRecordedOffset = (long) offsetMap.get(KEY_OFFSET);
-          consumer.seek(tp, lastRecordedOffset);
+          Long lastRecordedOffset = (Long) offsetMap.get(KEY_OFFSET);
+          // check if offset has been set to null, i.e. tombstone record
+          if (lastRecordedOffset != null) {
+            consumer.seek(tp, lastRecordedOffset);
+          }
         });
   }
 

--- a/src/main/java/com/salesforce/mirus/offsets/MirusOffsetTool.java
+++ b/src/main/java/com/salesforce/mirus/offsets/MirusOffsetTool.java
@@ -16,6 +16,7 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.Map;
+import java.util.stream.Stream;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.connect.json.JsonConverter;
 import org.apache.kafka.connect.runtime.distributed.DistributedConfig;
@@ -63,6 +64,9 @@ public class MirusOffsetTool {
     if (args.resetOffsets && (args.fromFile == null || args.fromFile.isEmpty())) {
       throw new ParameterException("--reset-offsets requires --from-file to be set");
     }
+    if (args.writeNullOffsets && !args.describe) {
+      throw new ParameterException("--show-nulls requires --describe to be set");
+    }
 
     MirusOffsetTool mirusOffsetTool = newOffsetTool(args);
     mirusOffsetTool.run();
@@ -97,7 +101,14 @@ public class MirusOffsetTool {
     if (args.describe) {
       offsetFetcher.start();
       try {
-        offsetSerDe.write(offsetFetcher.readOffsets(), System.out);
+        Stream<OffsetInfo> offsetInfos =
+            offsetFetcher
+                .readOffsets()
+                .filter(
+                    offsetInfo ->
+                        offsetInfo.offset != null
+                            || (offsetInfo.offset == null && args.writeNullOffsets));
+        offsetSerDe.write(offsetInfos, System.out);
       } finally {
         offsetFetcher.stop();
       }
@@ -121,6 +132,11 @@ public class MirusOffsetTool {
         names = {"--describe"},
         description = "Display all offsets stored in the offset storage topic")
     boolean describe;
+
+    @Parameter(
+        names = {"--show-nulls"},
+        description = "Include records with null offsets (tombstone records). Requires --describe ")
+    boolean writeNullOffsets = false;
 
     @Parameter(
         names = {"--reset-offsets"},

--- a/src/test/java/com/salesforce/mirus/MirusSourceTaskTest.java
+++ b/src/test/java/com/salesforce/mirus/MirusSourceTaskTest.java
@@ -8,8 +8,7 @@
 
 package com.salesforce.mirus;
 
-import static org.hamcrest.CoreMatchers.hasItems;
-import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
 
@@ -65,7 +64,7 @@ public class MirusSourceTaskTest {
             return new OffsetStorageReader() {
               @Override
               public <T> Map<String, Object> offset(Map<String, T> partition) {
-                return new HashMap<>(MirusSourceTask.offsetMap(0));
+                return new HashMap<>(MirusSourceTask.offsetMap(0L));
               }
 
               @Override

--- a/src/test/java/com/salesforce/mirus/offsets/OffsetSerDeTest.java
+++ b/src/test/java/com/salesforce/mirus/offsets/OffsetSerDeTest.java
@@ -47,11 +47,14 @@ public class OffsetSerDeTest {
     csvList =
         Arrays.asList(
             "connector-id,topic,1,123" + System.lineSeparator(),
-            "prd-logbus-source,sfdc.test.logbus__prd.ajna_test__logs.coreapp.sp1.logbus,2,345" + System.lineSeparator());
+            "prd-logbus-source,sfdc.test.logbus__prd.ajna_test__logs.coreapp.sp1.logbus,2,345"
+                + System.lineSeparator());
     jsonList =
         Arrays.asList(
-            "{\"connectorId\":\"connector-id\",\"topic\":\"topic\",\"partition\":1,\"offset\":123}" + System.lineSeparator(),
-            "{\"connectorId\":\"prd-logbus-source\",\"topic\":\"sfdc.test.logbus__prd.ajna_test__logs.coreapp.sp1.logbus\",\"partition\":2,\"offset\":345}" + System.lineSeparator());
+            "{\"connectorId\":\"connector-id\",\"topic\":\"topic\",\"partition\":1,\"offset\":123}"
+                + System.lineSeparator(),
+            "{\"connectorId\":\"prd-logbus-source\",\"topic\":\"sfdc.test.logbus__prd.ajna_test__logs.coreapp.sp1.logbus\",\"partition\":2,\"offset\":345}"
+                + System.lineSeparator());
   }
 
   @Test


### PR DESCRIPTION
In order to support the ability to delete offset entries in the Mirus configured offset topic, the offset tool should be able to handle offset entries of null. Kafka will eventually delete records in a compact topic that has the same key value of a tombstone record. This deletion doesn't happen instantly and depends on different configuration settings.
An outcome of this feature of handling null offsets is the ability of a consumer application, such as an offset checker, to have offsets of partitions of a deleted topic marked with a tombstone record and therefore filtered out.