### PR TITLE
Handle tombstone records in offset tool (#1)

### DIFF
--- a/src/test/java/com/salesforce/mirus/MirusSourceTaskTest.java
+++ b/src/test/java/com/salesforce/mirus/MirusSourceTaskTest.java
@@ -8,8 +8,7 @@
 
 package com.salesforce.mirus;
 
-import static org.hamcrest.CoreMatchers.hasItems;
-import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
 
@@ -65,7 +64,7 @@ public class MirusSourceTaskTest {
             return new OffsetStorageReader() {
               @Override
               public <T> Map<String, Object> offset(Map<String, T> partition) {
-                return new HashMap<>(MirusSourceTask.offsetMap(0));
+                return new HashMap<>(MirusSourceTask.offsetMap(0L));
               }
 
               @Override

--- a/src/test/java/com/salesforce/mirus/offsets/OffsetSerDeTest.java
+++ b/src/test/java/com/salesforce/mirus/offsets/OffsetSerDeTest.java
@@ -37,21 +37,29 @@ public class OffsetSerDeTest {
 
     List<OffsetInfo> offsetInfoList = new ArrayList<>();
     offsetInfoList.add(new OffsetInfo("connector-id", "topic", 1L, 123L));
+    offsetInfoList.add(new OffsetInfo("connector-id", "topic", 2L, null));
     offsetInfoList.add(
         new OffsetInfo(
             "prd-logbus-source",
             "sfdc.test.logbus__prd.ajna_test__logs.coreapp.sp1.logbus",
             2L,
             345L));
+
     offsetInfoStream = offsetInfoList.stream();
     csvList =
         Arrays.asList(
             "connector-id,topic,1,123" + System.lineSeparator(),
-            "prd-logbus-source,sfdc.test.logbus__prd.ajna_test__logs.coreapp.sp1.logbus,2,345" + System.lineSeparator());
+            "connector-id,topic,2," + System.lineSeparator(),
+            "prd-logbus-source,sfdc.test.logbus__prd.ajna_test__logs.coreapp.sp1.logbus,2,345"
+                + System.lineSeparator());
     jsonList =
         Arrays.asList(
-            "{\"connectorId\":\"connector-id\",\"topic\":\"topic\",\"partition\":1,\"offset\":123}" + System.lineSeparator(),
-            "{\"connectorId\":\"prd-logbus-source\",\"topic\":\"sfdc.test.logbus__prd.ajna_test__logs.coreapp.sp1.logbus\",\"partition\":2,\"offset\":345}" + System.lineSeparator());
+            "{\"connectorId\":\"connector-id\",\"topic\":\"topic\",\"partition\":1,\"offset\":123}"
+                + System.lineSeparator(),
+            "{\"connectorId\":\"connector-id\",\"topic\":\"topic\",\"partition\":2,\"offset\":null}"
+                + System.lineSeparator(),
+            "{\"connectorId\":\"prd-logbus-source\",\"topic\":\"sfdc.test.logbus__prd.ajna_test__logs.coreapp.sp1.logbus\",\"partition\":2,\"offset\":345}"
+                + System.lineSeparator());
   }
 
   @Test


### PR DESCRIPTION
* Handle tombstone records in offset tool

In order to support the ability to delete offset entries in the Mirus configured offset topic, the offset tool should be able to handle offset entries of null. Kafka will eventually delete records in a compact topic that has the same key value of a tombstone record. This deletion doesn't happen instantly and depends on different configuration settings.
An outcome of this feature of handling null offsets is the ability of a consumer application, such as an offset checker, to have offsets of partitions of a deleted topic marked with a tombstone record and therefore filtered out.