### PR TITLE
Support KafkaConnect Records via Converters

### DIFF
--- a/src/main/java/com/salesforce/mirus/MirusSourceTask.java
+++ b/src/main/java/com/salesforce/mirus/MirusSourceTask.java
@@ -23,10 +23,11 @@ import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.WakeupException;
 import org.apache.kafka.common.header.Headers;
-import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaAndValue;
 import org.apache.kafka.connect.header.ConnectHeaders;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.apache.kafka.connect.source.SourceTask;
+import org.apache.kafka.connect.storage.Converter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -57,6 +58,9 @@ public class MirusSourceTask extends SourceTask {
   private String destinationTopicNameSuffix;
   private Consumer<byte[], byte[]> consumer;
   private boolean enablePartitionMatching = false;
+
+  private Converter keyConverter;
+  private Converter valueConverter;
 
   protected AtomicBoolean shutDown = new AtomicBoolean(false);
 
@@ -93,6 +97,9 @@ public class MirusSourceTask extends SourceTask {
     this.destinationTopicNameSuffix = config.getDestinationTopicNameSuffix();
     this.enablePartitionMatching = config.getEnablePartitionMatching();
 
+    this.keyConverter = config.getKeyConverter();
+    this.valueConverter = config.getValueConverter();
+
     logger.debug("Task starting with partitions: {}", config.getInternalTaskPartitions());
 
     this.consumer = consumerFactory.newConsumer(consumerProperties);
@@ -111,7 +118,7 @@ public class MirusSourceTask extends SourceTask {
     }
   }
 
-  protected void shutDownTask() {
+  private void shutDownTask() {
     logger.debug("Task shutting down");
     consumer.close();
   }
@@ -193,6 +200,13 @@ public class MirusSourceTask extends SourceTask {
       sourceHeaders.forEach(header -> connectHeaders.addBytes(header.key(), header.value()));
     }
 
+    String topic = destinationTopicNamePrefix + consumerRecord.topic() + destinationTopicNameSuffix;
+
+    SchemaAndValue keyAndSchema = this.keyConverter.toConnectData(topic, consumerRecord.key());
+
+    SchemaAndValue valueAndSchema =
+        this.valueConverter.toConnectData(topic, consumerRecord.value());
+
     /*
      * NOTE: By adding one to the offset here we are following the Kafka convention that the
      * committed offset should always be the offset of the *next* message that your application will
@@ -201,12 +215,12 @@ public class MirusSourceTask extends SourceTask {
     return new SourceRecord(
         sourcePartition,
         offsetMap(consumerRecord.offset() + 1),
-        destinationTopicNamePrefix + consumerRecord.topic() + destinationTopicNameSuffix,
+        topic,
         enablePartitionMatching ? consumerRecord.partition() : null,
-        Schema.OPTIONAL_BYTES_SCHEMA,
-        consumerRecord.key(),
-        Schema.OPTIONAL_BYTES_SCHEMA,
-        consumerRecord.value(),
+        keyAndSchema.schema(),
+        keyAndSchema.value(),
+        valueAndSchema.schema(),
+        valueAndSchema.value(),
         consumerRecord.timestamp(),
         connectHeaders);
   }

--- a/src/main/java/com/salesforce/mirus/config/SourceConfigDefinition.java
+++ b/src/main/java/com/salesforce/mirus/config/SourceConfigDefinition.java
@@ -74,6 +74,12 @@ public enum SourceConfigDefinition {
       "org.apache.kafka.connect.converters.ByteArrayConverter",
       ConfigDef.Importance.MEDIUM,
       "Converter class to apply to source record values"),
+  SOURCE_HEADER_CONVERTER(
+      "source.header.converter",
+      ConfigDef.Type.CLASS,
+      "org.apache.kafka.connect.converters.ByteArrayConverter",
+      ConfigDef.Importance.MEDIUM,
+      "Converter class to apply to source record headers"),
   DESTINATION_BOOTSTRAP_SERVERS(
       "destination.bootstrap.servers",
       ConfigDef.Type.STRING,

--- a/src/main/java/com/salesforce/mirus/config/SourceConfigDefinition.java
+++ b/src/main/java/com/salesforce/mirus/config/SourceConfigDefinition.java
@@ -62,6 +62,18 @@ public enum SourceConfigDefinition {
       false,
       ConfigDef.Importance.MEDIUM,
       "Ensures records are written to the destination partition with the same identifier as the source partition"),
+  SOURCE_KEY_CONVERTER(
+      "source.key.converter",
+      ConfigDef.Type.CLASS,
+      "org.apache.kafka.connect.converters.ByteArrayConverter",
+      ConfigDef.Importance.MEDIUM,
+      "Converter class to apply to source record keys"),
+  SOURCE_VALUE_CONVERTER(
+      "source.value.converter",
+      ConfigDef.Type.CLASS,
+      "org.apache.kafka.connect.converters.ByteArrayConverter",
+      ConfigDef.Importance.MEDIUM,
+      "Converter class to apply to source record values"),
   DESTINATION_BOOTSTRAP_SERVERS(
       "destination.bootstrap.servers",
       ConfigDef.Type.STRING,

--- a/src/main/java/com/salesforce/mirus/config/TaskConfig.java
+++ b/src/main/java/com/salesforce/mirus/config/TaskConfig.java
@@ -11,6 +11,7 @@ package com.salesforce.mirus.config;
 import java.util.*;
 import org.apache.kafka.connect.storage.Converter;
 import org.apache.kafka.connect.storage.ConverterType;
+import org.apache.kafka.connect.storage.HeaderConverter;
 import org.apache.kafka.connect.storage.StringConverterConfig;
 import org.apache.kafka.connect.transforms.util.SimpleConfig;
 
@@ -89,5 +90,15 @@ public class TaskConfig {
 
     return config.getConfiguredInstance(
         SourceConfigDefinition.SOURCE_VALUE_CONVERTER.key, Converter.class);
+  }
+
+  public HeaderConverter getHeaderConverter() {
+    Map<String, Object> conf = simpleConfig.originals();
+    conf.put(StringConverterConfig.TYPE_CONFIG, ConverterType.HEADER.getName());
+
+    SimpleConfig config = new SimpleConfig(TaskConfigDefinition.configDef(), conf);
+
+    return config.getConfiguredInstance(
+        SourceConfigDefinition.SOURCE_HEADER_CONVERTER.key, HeaderConverter.class);
   }
 }

--- a/src/main/java/com/salesforce/mirus/config/TaskConfig.java
+++ b/src/main/java/com/salesforce/mirus/config/TaskConfig.java
@@ -8,9 +8,10 @@
 
 package com.salesforce.mirus.config;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
+import org.apache.kafka.connect.storage.Converter;
+import org.apache.kafka.connect.storage.ConverterType;
+import org.apache.kafka.connect.storage.StringConverterConfig;
 import org.apache.kafka.connect.transforms.util.SimpleConfig;
 
 /**
@@ -68,5 +69,25 @@ public class TaskConfig {
 
   public boolean getEnablePartitionMatching() {
     return simpleConfig.getBoolean(SourceConfigDefinition.ENABLE_PARTITION_MATCHING.key);
+  }
+
+  public Converter getKeyConverter() {
+    Map<String, Object> conf = simpleConfig.originals();
+    conf.put(StringConverterConfig.TYPE_CONFIG, ConverterType.KEY.getName());
+
+    SimpleConfig config = new SimpleConfig(TaskConfigDefinition.configDef(), conf);
+
+    return config.getConfiguredInstance(
+        SourceConfigDefinition.SOURCE_KEY_CONVERTER.key, Converter.class);
+  }
+
+  public Converter getValueConverter() {
+    Map<String, Object> conf = simpleConfig.originals();
+    conf.put(StringConverterConfig.TYPE_CONFIG, ConverterType.VALUE.getName());
+
+    SimpleConfig config = new SimpleConfig(TaskConfigDefinition.configDef(), conf);
+
+    return config.getConfiguredInstance(
+        SourceConfigDefinition.SOURCE_VALUE_CONVERTER.key, Converter.class);
   }
 }

--- a/src/main/java/com/salesforce/mirus/config/TaskConfigDefinition.java
+++ b/src/main/java/com/salesforce/mirus/config/TaskConfigDefinition.java
@@ -22,7 +22,9 @@ public class TaskConfigDefinition {
           SourceConfigDefinition.POLL_TIMEOUT_MS,
           SourceConfigDefinition.DESTINATION_TOPIC_NAME_PREFIX,
           SourceConfigDefinition.DESTINATION_TOPIC_NAME_SUFFIX,
-          SourceConfigDefinition.ENABLE_PARTITION_MATCHING);
+          SourceConfigDefinition.ENABLE_PARTITION_MATCHING,
+          SourceConfigDefinition.SOURCE_KEY_CONVERTER,
+          SourceConfigDefinition.SOURCE_VALUE_CONVERTER);
 
   static ConfigDef configDef() {
     ConfigDef configDef = new ConfigDef();

--- a/src/main/java/com/salesforce/mirus/config/TaskConfigDefinition.java
+++ b/src/main/java/com/salesforce/mirus/config/TaskConfigDefinition.java
@@ -24,7 +24,8 @@ public class TaskConfigDefinition {
           SourceConfigDefinition.DESTINATION_TOPIC_NAME_SUFFIX,
           SourceConfigDefinition.ENABLE_PARTITION_MATCHING,
           SourceConfigDefinition.SOURCE_KEY_CONVERTER,
-          SourceConfigDefinition.SOURCE_VALUE_CONVERTER);
+          SourceConfigDefinition.SOURCE_VALUE_CONVERTER,
+          SourceConfigDefinition.SOURCE_HEADER_CONVERTER);
 
   static ConfigDef configDef() {
     ConfigDef configDef = new ConfigDef();

--- a/src/test/java/com/salesforce/mirus/MirusSourceTaskTest.java
+++ b/src/test/java/com/salesforce/mirus/MirusSourceTaskTest.java
@@ -12,6 +12,7 @@ import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
 
+import com.salesforce.mirus.config.SourceConfigDefinition;
 import com.salesforce.mirus.config.TaskConfigDefinition;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -19,6 +20,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -33,6 +35,8 @@ import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.connect.data.ConnectSchema;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.header.Header;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.apache.kafka.connect.source.SourceTaskContext;
@@ -158,6 +162,51 @@ public class MirusSourceTaskTest {
             .map(Header::value)
             .collect(Collectors.toList()),
         hasItems("v1".getBytes(StandardCharsets.UTF_8), "v2".getBytes(StandardCharsets.UTF_8)));
+  }
+
+  @Test
+  public void testSourceRecordsWorksWithHeadersWithHeaderConverter() {
+    final String topic = "topica";
+    final int partition = 0;
+    final int offset = 123;
+    final long timestamp = 314159;
+
+    Map<String, String> properties = mockTaskProperties();
+    properties.put(
+        SourceConfigDefinition.SOURCE_HEADER_CONVERTER.getKey(),
+        "org.apache.kafka.connect.json.JsonConverter");
+
+    mirusSourceTask.start(properties);
+
+    Map<TopicPartition, List<ConsumerRecord<byte[], byte[]>>> records = new HashMap<>();
+    Headers headers = new RecordHeaders();
+    headers.add(
+        "h1",
+        "{\"schema\": {\"type\": \"struct\",\"fields\": [{\"type\": \"string\",\"optional\": true,\"field\": \"version\"}],\"optional\": false},\"payload\": {\"version\": \"v1\"}}"
+            .getBytes(StandardCharsets.UTF_8));
+    headers.add(
+        "h2",
+        "{\"schema\": {\"type\": \"struct\",\"fields\": [{\"type\": \"string\",\"optional\": true,\"field\": \"version\"}],\"optional\": false},\"payload\": {\"version\": \"v2\"}}"
+            .getBytes(StandardCharsets.UTF_8));
+    records.put(
+        new TopicPartition(topic, partition),
+        Collections.singletonList(newConsumerRecord(topic, partition, offset, timestamp, headers)));
+    ConsumerRecords<byte[], byte[]> pollResult = new ConsumerRecords<>(records);
+
+    List<SourceRecord> result = mirusSourceTask.sourceRecords(pollResult);
+
+    Iterator<Header> connectHeaders = result.get(0).headers().iterator();
+    Header header1 = connectHeaders.next();
+    assertThat(header1.key(), is("h1"));
+    assertThat(header1.value(), instanceOf(Struct.class));
+    Struct header1Value = (Struct) header1.value();
+    assertThat(header1Value.getString("version"), is("v1"));
+
+    Header header2 = connectHeaders.next();
+    assertThat(header2.key(), is("h2"));
+    assertThat(header2.value(), instanceOf(Struct.class));
+    Struct header2Value = (Struct) header2.value();
+    assertThat(header2Value.getString("version"), is("v2"));
   }
 
   @Test

--- a/src/test/java/com/salesforce/mirus/config/TaskConfigTest.java
+++ b/src/test/java/com/salesforce/mirus/config/TaskConfigTest.java
@@ -16,7 +16,6 @@ import static org.hamcrest.Matchers.is;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-
 import org.apache.kafka.connect.converters.ByteArrayConverter;
 import org.apache.kafka.connect.json.JsonConverter;
 import org.junit.Assert;
@@ -57,6 +56,7 @@ public class TaskConfigTest {
     TaskConfig taskConfig = new TaskConfig(Collections.emptyMap());
     assertThat(taskConfig.getKeyConverter(), instanceOf(ByteArrayConverter.class));
     assertThat(taskConfig.getValueConverter(), instanceOf(ByteArrayConverter.class));
+    assertThat(taskConfig.getHeaderConverter(), instanceOf(ByteArrayConverter.class));
   }
 
   @Test
@@ -64,10 +64,12 @@ public class TaskConfigTest {
     properties = new HashMap<>();
     properties.put("source.key.converter", "org.apache.kafka.connect.json.JsonConverter");
     properties.put("source.value.converter", "org.apache.kafka.connect.json.JsonConverter");
+    properties.put("source.header.converter", "org.apache.kafka.connect.json.JsonConverter");
 
     TaskConfig taskConfig = new TaskConfig(properties);
     assertThat(taskConfig.getKeyConverter(), instanceOf(JsonConverter.class));
     assertThat(taskConfig.getValueConverter(), instanceOf(JsonConverter.class));
+    assertThat(taskConfig.getHeaderConverter(), instanceOf(JsonConverter.class));
   }
 
   @Test

--- a/src/test/java/com/salesforce/mirus/config/TaskConfigTest.java
+++ b/src/test/java/com/salesforce/mirus/config/TaskConfigTest.java
@@ -10,11 +10,15 @@ package com.salesforce.mirus.config;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+
+import org.apache.kafka.connect.converters.ByteArrayConverter;
+import org.apache.kafka.connect.json.JsonConverter;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -46,6 +50,24 @@ public class TaskConfigTest {
     TaskConfig taskConfig = new TaskConfig(Collections.emptyMap());
     assertThat(taskConfig.getInternalTaskPartitions(), is(""));
     assertThat(taskConfig.getEnablePartitionMatching(), is(false));
+  }
+
+  @Test
+  public void defaultConvertersShouldBeByteArray() {
+    TaskConfig taskConfig = new TaskConfig(Collections.emptyMap());
+    assertThat(taskConfig.getKeyConverter(), instanceOf(ByteArrayConverter.class));
+    assertThat(taskConfig.getValueConverter(), instanceOf(ByteArrayConverter.class));
+  }
+
+  @Test
+  public void customConvertersShouldBeInstantiated() {
+    properties = new HashMap<>();
+    properties.put("source.key.converter", "org.apache.kafka.connect.json.JsonConverter");
+    properties.put("source.value.converter", "org.apache.kafka.connect.json.JsonConverter");
+
+    TaskConfig taskConfig = new TaskConfig(properties);
+    assertThat(taskConfig.getKeyConverter(), instanceOf(JsonConverter.class));
+    assertThat(taskConfig.getValueConverter(), instanceOf(JsonConverter.class));
   }
 
   @Test


### PR DESCRIPTION
This allows the Task to be able to create SourceRecords which might be coming from an already generated Kafka Connect Record.

More context: https://github.com/salesforce/mirus/issues/25#issuecomment-444964030