### PR TITLE
Override classpath only if not set

### DIFF
--- a/bin/mirus-worker-start.sh
+++ b/bin/mirus-worker-start.sh
@@ -16,7 +16,7 @@ readonly base_dir=$(cd $(dirname "$0")/.. && pwd -P)  # Platform independent
 
 MIRUS_MAIN_CLASS=${MIRUS_MAIN_CLASS:-com.salesforce.mirus.Mirus}
 
-CLASSPATH=$(find ${base_dir} -name 'mirus.jar')
+CLASSPATH=${CLASSPATH:-"$(find ${base_dir} -name 'mirus.jar')"}
 
 # Log directory to use.
 if [ -z "${LOG_DIR}" ]; then


### PR DESCRIPTION
If classpath is not set, then default to the mirus.jar uber JAR. Otherwise, use the already-set classpath.