### PR TITLE
Update to Kafka Connect 2.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <properties>
         <dist.dir>${project.build.directory}/dist</dist.dir>
         <java.numeric.version>1.8</java.numeric.version>
-        <kafka.version>2.1.1</kafka.version>
+        <kafka.version>2.2.0</kafka.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 


### PR DESCRIPTION
Upgrade and merge recent upstream changes from `ConnectDistributed`, including calling `rest.start` in `startConnect` as identified in issue #36.