### PR TITLE
Handle topic renaming when checking destination partitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,17 @@ Worker Properties file provided at startup. The Kafka Producer instances created
 can also be configured using a `producer.` prefix on the standard
 [Kafka Producer properties](https://kafka.apache.org/documentation/#producerconfigs).
 
+## Destination Topic Checking
+
+By default, Mirus checks that the destination topic exists in the destination Kafka cluster before
+stating to replicate data to it. This feature can be disabled by setting the
+[enable.destination.topic.checking](src/main/java/com/salesforce/mirus/config/SourceConfigDefinition.java#L66)
+config option to `false`.
+
+As of version 0.2.0, destination topic checking can also support topic re-routing performed by the
+[RegexRouter](https://kafka.apache.org/documentation/#connect_transforms) Single-Message Transformation.
+No other `Router` Transformations are supported, so destination topic checking must be disabled in order
+to use them.
 
 ## Developer Info
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.salesforce.mirus</groupId>
     <artifactId>mirus</artifactId>
-    <version>0.1.3-SNAPSHOT</version>
+    <version>0.2.0-SNAPSHOT</version>
 
     <name>Mirus</name>
     <description>Apache Kafka data replication tool based on Kafka Connect</description>

--- a/src/main/java/com/salesforce/mirus/config/SourceConfig.java
+++ b/src/main/java/com/salesforce/mirus/config/SourceConfig.java
@@ -51,6 +51,10 @@ public class SourceConfig {
     return simpleConfig.getBoolean(SourceConfigDefinition.ENABLE_PARTITION_MATCHING.key);
   }
 
+  public boolean getTopicCheckingEnabled() {
+    return simpleConfig.getBoolean(SourceConfigDefinition.ENABLE_DESTINATION_TOPIC_CHECKING.key);
+  }
+
   public String getName() {
     return simpleConfig.getString(ConnectorConfig.NAME_CONFIG);
   }

--- a/src/main/java/com/salesforce/mirus/config/SourceConfigDefinition.java
+++ b/src/main/java/com/salesforce/mirus/config/SourceConfigDefinition.java
@@ -11,6 +11,8 @@ package com.salesforce.mirus.config;
 import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.ConfigDef.ConfigKey;
+import org.apache.kafka.connect.runtime.ConnectorConfig;
 
 /**
  * Properties listed here can be applied to the MirusSourceConnector configuration object, which is
@@ -19,7 +21,6 @@ import org.apache.kafka.common.config.ConfigDef;
  * information on the destination cluster for topic metadata validation.
  */
 public enum SourceConfigDefinition {
-  NAME("name", ConfigDef.Type.STRING, "", ConfigDef.Importance.HIGH, "Unique name for this source"),
   TOPICS_WHITELIST(
       "topics.whitelist",
       ConfigDef.Type.LIST,
@@ -110,6 +111,13 @@ public enum SourceConfigDefinition {
     ConfigDef configDef = new ConfigDef();
     for (SourceConfigDefinition f : SourceConfigDefinition.values()) {
       configDef = configDef.define(f.key, f.type, f.defaultValue, f.importance, f.doc);
+    }
+
+    // Share name and transforms config definitions from ConnectorConfig
+    for (ConfigKey key : ConnectorConfig.configDef().configKeys().values()) {
+      if ("Transforms".equals(key.group) || ConnectorConfig.NAME_CONFIG.equals(key.name)) {
+        configDef.define(key);
+      }
     }
     return configDef;
   }

--- a/src/main/java/com/salesforce/mirus/config/SourceConfigDefinition.java
+++ b/src/main/java/com/salesforce/mirus/config/SourceConfigDefinition.java
@@ -63,6 +63,15 @@ public enum SourceConfigDefinition {
       false,
       ConfigDef.Importance.MEDIUM,
       "Ensures records are written to the destination partition with the same identifier as the source partition"),
+  ENABLE_DESTINATION_TOPIC_CHECKING(
+      "enable.destination.topic.checking",
+      ConfigDef.Type.BOOLEAN,
+      true,
+      ConfigDef.Importance.LOW,
+      "Enables destination topic checking to ensure the topic exists in the destination cluster."
+          + " Supports the RegexRouter SMT but not other Router transformations or other topic-rerouting"
+          + " transformations. Disable to use other Kafka Connect Transformations to reroute messages"
+          + "to different topics."),
   SOURCE_KEY_CONVERTER(
       "source.key.converter",
       ConfigDef.Type.CLASS,

--- a/src/test/java/com/salesforce/mirus/SourcePartitionValidatorTest.java
+++ b/src/test/java/com/salesforce/mirus/SourcePartitionValidatorTest.java
@@ -13,6 +13,7 @@ import static org.junit.Assert.assertThat;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.Function;
 import org.apache.kafka.clients.consumer.MockConsumer;
 import org.apache.kafka.clients.consumer.OffsetResetStrategy;
 import org.apache.kafka.common.PartitionInfo;
@@ -37,7 +38,8 @@ public class SourcePartitionValidatorTest {
   @Test
   public void testIsHealthyWithTopicMatcher() {
     SourcePartitionValidator sourcePartitionHealthChecker =
-        new SourcePartitionValidator(mockConsumer, SourcePartitionValidator.MatchingStrategy.TOPIC);
+        new SourcePartitionValidator(
+            mockConsumer, SourcePartitionValidator.MatchingStrategy.TOPIC, Function.identity());
     assertThat(sourcePartitionHealthChecker.isHealthy(new TopicPartition("topic1", 0)), is(true));
     assertThat(sourcePartitionHealthChecker.isHealthy(new TopicPartition("topic1", 2)), is(true));
     assertThat(sourcePartitionHealthChecker.isHealthy(new TopicPartition("topic2", 0)), is(false));
@@ -47,9 +49,28 @@ public class SourcePartitionValidatorTest {
   public void testIsHealthyWithPartitionMatcher() {
     SourcePartitionValidator sourcePartitionHealthChecker =
         new SourcePartitionValidator(
-            mockConsumer, SourcePartitionValidator.MatchingStrategy.PARTITION);
+            mockConsumer, SourcePartitionValidator.MatchingStrategy.PARTITION, Function.identity());
     assertThat(sourcePartitionHealthChecker.isHealthy(new TopicPartition("topic1", 0)), is(true));
     assertThat(sourcePartitionHealthChecker.isHealthy(new TopicPartition("topic1", 2)), is(false));
+    assertThat(sourcePartitionHealthChecker.isHealthy(new TopicPartition("topic2", 0)), is(false));
+  }
+
+  @Test
+  public void shouldApplyTopicRenameWhenCheckingHealth() {
+    MockConsumer<byte[], byte[]> consumer = new MockConsumer<>(OffsetResetStrategy.EARLIEST);
+    List<PartitionInfo> partitionInfoList =
+        Arrays.asList(
+            new PartitionInfo("replace1", 0, null, null, null),
+            new PartitionInfo("replace1", 1, null, null, null));
+    consumer.updatePartitions("replace1", partitionInfoList);
+
+    SourcePartitionValidator sourcePartitionHealthChecker =
+        new SourcePartitionValidator(
+            consumer,
+            SourcePartitionValidator.MatchingStrategy.TOPIC,
+            t -> t.equals("topic1") ? "replace1" : t);
+    assertThat(sourcePartitionHealthChecker.isHealthy(new TopicPartition("topic1", 0)), is(true));
+    assertThat(sourcePartitionHealthChecker.isHealthy(new TopicPartition("topic1", 2)), is(true));
     assertThat(sourcePartitionHealthChecker.isHealthy(new TopicPartition("topic2", 0)), is(false));
   }
 }

--- a/src/test/java/com/salesforce/mirus/TaskConfigBuilderTest.java
+++ b/src/test/java/com/salesforce/mirus/TaskConfigBuilderTest.java
@@ -8,13 +8,11 @@
 
 package com.salesforce.mirus;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.assertThat;
 
 import com.salesforce.mirus.assignment.RoundRobinTaskAssignor;
 import com.salesforce.mirus.config.SourceConfig;
-import com.salesforce.mirus.config.SourceConfigDefinition;
 import com.salesforce.mirus.config.TaskConfigDefinition;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -23,6 +21,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.connect.runtime.ConnectorConfig;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -31,7 +30,7 @@ public class TaskConfigBuilderTest {
   private List<TopicPartition> topicPartitionList;
 
   private TaskConfigBuilder newBuilder(Map<String, String> properties) {
-    properties.put(SourceConfigDefinition.NAME.getKey(), "source-name");
+    properties.put(ConnectorConfig.NAME_CONFIG, "source-name");
     properties.put(TaskConfigDefinition.CONSUMER_CLIENT_ID, "test-");
     return new TaskConfigBuilder(new RoundRobinTaskAssignor(), new SourceConfig(properties));
   }


### PR DESCRIPTION
Add support for RegexRouter transforms and topic name prefixes and
suffixes when checking the destination cluster for topic name.
Previously the KafkaMonitor only checked for the original topic name,
even if messages would be replicated to a different topic.

Prefixes and suffixes are applied first, since transforms are only
applied to records after being returned from the MirusSourceTask::poll
method.

Other routers aren't currently supported. The Kafka Connect
TimestampRouter routes based of information within each message, so
the required topic name can't be determined ahead of time. The
KafkaMonitor assumes any transform that contains the phrase "Router"
would rename topics and logs a warning about mirroring when identified.