### PR TITLE
Use zero index for KafkaMonitorBackoff

### DIFF
--- a/src/main/java/com/salesforce/mirus/KafkaMonitor.java
+++ b/src/main/java/com/salesforce/mirus/KafkaMonitor.java
@@ -204,8 +204,7 @@ class KafkaMonitor implements Runnable {
 
   private void exponentialBackoffWait(int numErrors) {
     int secondsToWait =
-        BACKOFF_WAIT_SECONDS[
-            numErrors < BACKOFF_WAIT_SECONDS.length ? numErrors : BACKOFF_WAIT_SECONDS.length - 1];
+        BACKOFF_WAIT_SECONDS[Math.min(Math.max(numErrors - 1, 0), BACKOFF_WAIT_SECONDS.length - 1)];
     if (secondsToWait > 0) {
       try {
         TimeUnit.SECONDS.sleep(secondsToWait);


### PR DESCRIPTION
To correctly start at the first backoff wait of 0 seconds we need to
start at index 0, which is one less than the number of consecutive
errors. Wrap in a min/max check to ensure we stay within the bounds of
the BACKOFF_WAIT_SECONDS array.