### PR TITLE
Upgrade to Kafka 2.3.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,7 @@
 
     <properties>
         <dist.dir>${project.build.directory}/dist</dist.dir>
+        <jackson.version>2.10.0</jackson.version>
         <java.numeric.version>1.8</java.numeric.version>
         <kafka.version>2.3.1</kafka.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -25,7 +26,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-csv</artifactId>
-            <version>2.9.4</version>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <properties>
         <dist.dir>${project.build.directory}/dist</dist.dir>
         <java.numeric.version>1.8</java.numeric.version>
-        <kafka.version>2.2.0</kafka.version>
+        <kafka.version>2.3.1</kafka.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/src/main/java/com/salesforce/mirus/Mirus.java
+++ b/src/main/java/com/salesforce/mirus/Mirus.java
@@ -22,7 +22,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.common.utils.Exit;
 import org.apache.kafka.common.utils.Time;

--- a/src/main/java/com/salesforce/mirus/Mirus.java
+++ b/src/main/java/com/salesforce/mirus/Mirus.java
@@ -22,12 +22,13 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.common.utils.Exit;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
+import org.apache.kafka.connect.connector.policy.ConnectorClientConfigOverridePolicy;
 import org.apache.kafka.connect.runtime.Connect;
-import org.apache.kafka.connect.runtime.HerderProvider;
 import org.apache.kafka.connect.runtime.Worker;
 import org.apache.kafka.connect.runtime.WorkerConfig;
 import org.apache.kafka.connect.runtime.WorkerConfigTransformer;
@@ -148,8 +149,7 @@ public class Mirus {
     log.debug("Kafka cluster ID: {}", kafkaClusterId);
 
     RestServer rest = new RestServer(configWithClientIdSuffix(workerProps, "rest"));
-    HerderProvider provider = new HerderProvider();
-    rest.start(provider, plugins);
+    rest.initializeServer();
 
     URI advertisedUrl = rest.advertisedUrl();
     String workerId = advertisedUrl.getHost() + ":" + advertisedUrl.getPort();
@@ -158,7 +158,22 @@ public class Mirus {
     offsetBackingStore.configure(configWithClientIdSuffix(workerProps, "offset"));
 
     WorkerConfig workerConfigs = configWithClientIdSuffix(workerProps, "worker");
-    Worker worker = new Worker(workerId, time, plugins, workerConfigs, offsetBackingStore);
+
+    ConnectorClientConfigOverridePolicy connectorClientConfigOverridePolicy =
+        plugins.newPlugin(
+            distributedConfig.getString(WorkerConfig.CONNECTOR_CLIENT_POLICY_CLASS_CONFIG),
+            workerConfigs,
+            ConnectorClientConfigOverridePolicy.class);
+
+    Worker worker =
+        new Worker(
+            workerId,
+            time,
+            plugins,
+            workerConfigs,
+            offsetBackingStore,
+            connectorClientConfigOverridePolicy);
+
     WorkerConfigTransformer configTransformer = worker.configTransformer();
 
     Converter internalValueConverter = worker.getInternalValueConverter();
@@ -180,7 +195,8 @@ public class Mirus {
             kafkaClusterId,
             statusBackingStore,
             configBackingStore,
-            advertisedUrl.toString());
+            advertisedUrl.toString(),
+            connectorClientConfigOverridePolicy);
 
     // Initialize HerderStatusMonitor
     boolean autoStartTasks = mirusConfig.getTaskAutoRestart();
@@ -196,8 +212,6 @@ public class Mirus {
     log.info("Mirus worker initialization took {}ms", time.hiResClockMs() - initStart);
     try {
       connect.start();
-      // herder has initialized now, and ready to be used by the RestServer.
-      provider.setHerder(herder);
     } catch (Exception e) {
       log.error("Failed to start Mirus", e);
       connect.stop();

--- a/src/test/java/com/salesforce/mirus/MirusSourceTaskTest.java
+++ b/src/test/java/com/salesforce/mirus/MirusSourceTaskTest.java
@@ -219,7 +219,7 @@ public class MirusSourceTaskTest {
     Map<TopicPartition, List<ConsumerRecord<byte[], byte[]>>> records = new HashMap<>();
     records.put(
         new TopicPartition(topic, partition),
-        Collections.singletonList(newConsumerRecord(topic, partition, offset, timestamp, null)));
+        Collections.singletonList(newConsumerRecord(topic, partition, offset, timestamp, new RecordHeaders())));
     ConsumerRecords<byte[], byte[]> pollResult = new ConsumerRecords<>(records);
 
     List<SourceRecord> result = mirusSourceTask.sourceRecords(pollResult);

--- a/src/test/java/com/salesforce/mirus/MirusSourceTaskTest.java
+++ b/src/test/java/com/salesforce/mirus/MirusSourceTaskTest.java
@@ -219,7 +219,8 @@ public class MirusSourceTaskTest {
     Map<TopicPartition, List<ConsumerRecord<byte[], byte[]>>> records = new HashMap<>();
     records.put(
         new TopicPartition(topic, partition),
-        Collections.singletonList(newConsumerRecord(topic, partition, offset, timestamp, new RecordHeaders())));
+        Collections.singletonList(
+            newConsumerRecord(topic, partition, offset, timestamp, new RecordHeaders())));
     ConsumerRecords<byte[], byte[]> pollResult = new ConsumerRecords<>(records);
 
     List<SourceRecord> result = mirusSourceTask.sourceRecords(pollResult);


### PR DESCRIPTION
### Upgrade to Kafka 2.3.1

- Upgrade library
- It's not possible to create records with `null` headers, thus we create an empty headers list with `new RecordHeaders()`
- Seems like it's not necessary to start the herder manually anymore, check https://github.com/apache/kafka/blob/2.3.0/connect/runtime/src/main/java/org/apache/kafka/connect/cli/ConnectDistributed.java#L99
- The renaming configs were kept and also the monitoring thread
- It's hard to test this since it requires some manual testing, please double check the work!

P.s.: Would you please make a new release after this?