### PR TITLE
Use openjdk8 in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 # On Travis set: SONATYPE_USERNAME, SONATYPE_PASSWORD, GPG_NAME, GPG_EMAIL
 
 language: java
-jdk: oraclejdk8
+jdk: openjdk8
 
 cache:
   directories:


### PR DESCRIPTION
This is required because `oraclejdk8` is not longer available. We should upgrade to `openjdk11` soon.