### PR TITLE
New destination consumer using prefix "destination." properties

### DIFF
--- a/src/main/java/com/salesforce/mirus/KafkaMonitor.java
+++ b/src/main/java/com/salesforce/mirus/KafkaMonitor.java
@@ -155,7 +155,7 @@ class KafkaMonitor implements Runnable {
   }
 
   private static Consumer<byte[], byte[]> newDestinationConsumer(SourceConfig config) {
-    Map<String, Object> consumerProperties = config.getConsumerProperties();
+    Map<String, Object> consumerProperties = config.getDestinationProperties();
 
     // The "monitor2" client id suffix is used to keep JMX bean names distinct
     consumerProperties.computeIfPresent(

--- a/src/main/java/com/salesforce/mirus/config/SourceConfig.java
+++ b/src/main/java/com/salesforce/mirus/config/SourceConfig.java
@@ -43,6 +43,10 @@ public class SourceConfig {
     return simpleConfig.originalsWithPrefix("consumer.");
   }
 
+  public Map<String, Object> getDestinationProperties() {
+    return simpleConfig.originalsWithPrefix("destination.");
+  }
+
   public String getDestinationBootstrapServers() {
     return simpleConfig.getString(SourceConfigDefinition.DESTINATION_BOOTSTRAP_SERVERS.key);
   }


### PR DESCRIPTION
Maybe it is better to use independent prefix "destination." properties for new destination consumer. Consider sample below:

```
"config": {
        "connector.class": "com.salesforce.mirus.MirusSourceConnector",
        "tasks.max": "50",
        "topics.whitelist": "mytopic",
        "destination.bootstrap.servers": "host1:9092",
        
        "consumer.bootstrap.servers": "host2:9093",
        "consumer.client.id": "mirus-replicator",
        "consumer.group.id": "sandbox-connect-mirus",
        "consumer.security.protocol": "SSL",
        "consumer.ssl.truststore.location": "/opt/ssl/client.truststore.jks",
        "consumer.ssl.truststore.password": "password",
        "consumer.ssl.endpoint.identification.algorithm": "",
        "consumer.key.deserializer": "org.apache.kafka.common.serialization.ByteArrayDeserializer",
        "consumer.value.deserializer": "org.apache.kafka.common.serialization.ByteArrayDeserializer"
    }
```

My source kafka must access by SSL, but destination kafka cannot access by SSL. So it cannot cover my demand.

I can have different configuration between source and destination if using independent prefix "destination." properties.

Then new configuration can be:
```
"config": {
        "connector.class": "com.salesforce.mirus.MirusSourceConnector",
        "tasks.max": "50",
        "topics.whitelist": "mytopic",
        "destination.bootstrap.servers": "host1:9092",
        "destination.client.id": "mirus-replicator-1",
        "destination.group.id": "sandbox-connect-mirus",
        "destination.key.deserializer": "org.apache.kafka.common.serialization.ByteArrayDeserializer",
        "destination.value.deserializer": "org.apache.kafka.common.serialization.ByteArrayDeserializer"
        "consumer.bootstrap.servers": "host2:9093",
        "consumer.client.id": "mirus-replicator-2",
        "consumer.group.id": "sandbox-connect-mirus",
        "consumer.security.protocol": "SSL",
        "consumer.ssl.truststore.location": "/opt/ssl/client.truststore.jks",
        "consumer.ssl.truststore.password": "password",
        "consumer.ssl.endpoint.identification.algorithm": "",
        "consumer.key.deserializer": "org.apache.kafka.common.serialization.ByteArrayDeserializer",
        "consumer.value.deserializer": "org.apache.kafka.common.serialization.ByteArrayDeserializer"
    }
```