### PR TITLE
source converter support configure

### DIFF
--- a/src/main/java/com/salesforce/mirus/config/TaskConfig.java
+++ b/src/main/java/com/salesforce/mirus/config/TaskConfig.java
@@ -78,8 +78,11 @@ public class TaskConfig {
 
     SimpleConfig config = new SimpleConfig(TaskConfigDefinition.configDef(), conf);
 
-    return config.getConfiguredInstance(
-        SourceConfigDefinition.SOURCE_KEY_CONVERTER.key, Converter.class);
+    Converter converter = config.getConfiguredInstance(
+            SourceConfigDefinition.SOURCE_KEY_CONVERTER.key, Converter.class);
+    converter.configure(
+            config.originalsWithPrefix(SourceConfigDefinition.SOURCE_KEY_CONVERTER.key + "."),true);
+    return converter;
   }
 
   public Converter getValueConverter() {
@@ -88,8 +91,11 @@ public class TaskConfig {
 
     SimpleConfig config = new SimpleConfig(TaskConfigDefinition.configDef(), conf);
 
-    return config.getConfiguredInstance(
-        SourceConfigDefinition.SOURCE_VALUE_CONVERTER.key, Converter.class);
+    Converter converter = config.getConfiguredInstance(
+            SourceConfigDefinition.SOURCE_VALUE_CONVERTER.key, Converter.class);
+    converter.configure(
+            config.originalsWithPrefix(SourceConfigDefinition.SOURCE_VALUE_CONVERTER.key + "."),false);
+    return converter;
   }
 
   public HeaderConverter getHeaderConverter() {
@@ -98,7 +104,10 @@ public class TaskConfig {
 
     SimpleConfig config = new SimpleConfig(TaskConfigDefinition.configDef(), conf);
 
-    return config.getConfiguredInstance(
-        SourceConfigDefinition.SOURCE_HEADER_CONVERTER.key, HeaderConverter.class);
+    HeaderConverter headerConverter = config.getConfiguredInstance(
+            SourceConfigDefinition.SOURCE_HEADER_CONVERTER.key, HeaderConverter.class);
+    headerConverter.configure(
+            config.originalsWithPrefix(SourceConfigDefinition.SOURCE_HEADER_CONVERTER.key + "."));
+    return headerConverter;
   }
 }


### PR DESCRIPTION
The configuration of the source converter is not supported. I can't set `schema.enable = false` when I use `JsonConverter`. It also cannot set the `schema.registry.url` for `KafkaAvroDeserializer`.

```
{
    ...
    "source.key.converter" : "org.apache.kafka.connect.json.JsonConverter",
    "source.key.converter.schemas.enable" : "false",
    "source.value.converter" : "org.apache.kafka.connect.json.JsonConverter",
    "source.value.converter.schemas.enable" : "false",
    ...
}

```