### PR TITLE
Add Task To Source Partition Log Entry

### DIFF
--- a/src/main/java/com/salesforce/mirus/MirusSourceTask.java
+++ b/src/main/java/com/salesforce/mirus/MirusSourceTask.java
@@ -103,7 +103,10 @@ public class MirusSourceTask extends SourceTask {
     this.valueConverter = config.getValueConverter();
     this.headerConverter = config.getHeaderConverter();
 
-    logger.debug("Task starting with partitions: {}", config.getInternalTaskPartitions());
+    logger.info(
+        "Starting task: (task id: {} partitions: {})",
+        config.getTaskId(),
+        config.getInternalTaskPartitions());
 
     this.consumer = consumerFactory.newConsumer(consumerProperties);
     List<TopicPartition> partitionIds =

--- a/src/main/java/com/salesforce/mirus/config/TaskConfig.java
+++ b/src/main/java/com/salesforce/mirus/config/TaskConfig.java
@@ -101,4 +101,8 @@ public class TaskConfig {
     return config.getConfiguredInstance(
         SourceConfigDefinition.SOURCE_HEADER_CONVERTER.key, HeaderConverter.class);
   }
+
+  public String getTaskId() {
+    return simpleConfig.getString(TaskConfigDefinition.TASK_ID);
+  }
 }

--- a/src/main/java/com/salesforce/mirus/config/TaskConfigDefinition.java
+++ b/src/main/java/com/salesforce/mirus/config/TaskConfigDefinition.java
@@ -16,6 +16,7 @@ public class TaskConfigDefinition {
 
   public static final String PARTITION_LIST = "partitions";
   public static final String CONSUMER_CLIENT_ID = "consumer.client.id";
+  public static final String TASK_ID = "task.id";
   /** List of config definitions to inherit from SourceConfig */
   private static final List<SourceConfigDefinition> SOURCE_CONFIG_DEFINITION_LIST =
       Arrays.asList(
@@ -45,6 +46,12 @@ public class TaskConfigDefinition {
         "",
         ConfigDef.Importance.HIGH,
         "Client ID used to uniquely identify the consumer in this task");
+    configDef.define(
+        TASK_ID,
+        ConfigDef.Type.STRING,
+        "",
+        ConfigDef.Importance.HIGH,
+        "Task ID used to uniquely identify the task");
     return configDef;
   }
 }


### PR DESCRIPTION
## What does this commit do?
Adds an info level log line which prints the task-partition mapping of
the task on task start.

## Why is this change being made?
To provide a simple way to find the task to partition mapping.

## How does this commit do it?
* Adding the task.id to the task definition.
* Changing a log line:
  * From debug to info level in MirusSourceTask
  * To output the task id in addition to the partition list

## How was this tested? How can the reviewer verify your testing?
Via a release to a mirus test cluster