### PR TITLE
Skip records that have already been consumed by a task

### DIFF
--- a/src/main/java/com/salesforce/mirus/Mirus.java
+++ b/src/main/java/com/salesforce/mirus/Mirus.java
@@ -55,7 +55,8 @@ import org.slf4j.LoggerFactory;
  *   <li>Supports worker property value overrides, in the same format as the Kafka Server, to
  *       simplify configuration
  *   <li>Ensure client.id for internal Kafka clients use unique names by adding suffixes
- *   <li>Initialize the {@link HerderStatusMonitor} for automated task restarts and enhanced monitoring
+ *   <li>Initialize the {@link HerderStatusMonitor} for automated task restarts and enhanced
+ *       monitoring
  * </ul>
  */
 public class Mirus {

--- a/src/main/java/com/salesforce/mirus/MirusSourceTask.java
+++ b/src/main/java/com/salesforce/mirus/MirusSourceTask.java
@@ -197,7 +197,7 @@ public class MirusSourceTask extends SourceTask {
           Long sourceOffset = consumerRecord.offset();
           Long latestOffset = latestOffsetMap.get(sourceRecord.sourcePartition());
 
-          // Skip records at have already been seen by this task
+          // Skip any record that has already been handled by this task
           if (latestOffset == null || sourceOffset > latestOffset ) {
             sourceRecords.add(sourceRecord);
             latestOffsetMap.put(sourceRecord.sourcePartition(), sourceOffset);

--- a/src/main/java/com/salesforce/mirus/config/TaskConfig.java
+++ b/src/main/java/com/salesforce/mirus/config/TaskConfig.java
@@ -8,7 +8,9 @@
 
 package com.salesforce.mirus.config;
 
-import java.util.*;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
 import org.apache.kafka.connect.storage.Converter;
 import org.apache.kafka.connect.storage.ConverterType;
 import org.apache.kafka.connect.storage.HeaderConverter;
@@ -20,6 +22,11 @@ import org.apache.kafka.connect.transforms.util.SimpleConfig;
  * {@link com.salesforce.mirus.MirusSourceTask} instances.
  */
 public class TaskConfig {
+
+  public enum ReplayPolicy {
+    IGNORE,
+    FILTER // Attempt to filter out duplicate records using the replay window
+  }
 
   private final SimpleConfig simpleConfig;
 
@@ -70,6 +77,14 @@ public class TaskConfig {
 
   public boolean getEnablePartitionMatching() {
     return simpleConfig.getBoolean(SourceConfigDefinition.ENABLE_PARTITION_MATCHING.key);
+  }
+
+  public ReplayPolicy getReplayPolicy() {
+    return ReplayPolicy.valueOf(simpleConfig.getString(TaskConfigDefinition.REPLAY_POLICY));
+  }
+
+  public long getReplayWindowRecords() {
+    return simpleConfig.getLong(TaskConfigDefinition.REPLAY_WINDOW_RECORDS);
   }
 
   public Converter getKeyConverter() {

--- a/src/main/java/com/salesforce/mirus/config/TaskConfigDefinition.java
+++ b/src/main/java/com/salesforce/mirus/config/TaskConfigDefinition.java
@@ -8,6 +8,7 @@
 
 package com.salesforce.mirus.config;
 
+import com.salesforce.mirus.config.TaskConfig.ReplayPolicy;
 import java.util.Arrays;
 import java.util.List;
 import org.apache.kafka.common.config.ConfigDef;
@@ -16,6 +17,9 @@ public class TaskConfigDefinition {
 
   public static final String PARTITION_LIST = "partitions";
   public static final String CONSUMER_CLIENT_ID = "consumer.client.id";
+  public static final String REPLAY_POLICY = "replay.policy";
+  public static final String REPLAY_WINDOW_RECORDS = "replay.window.records";
+
   /** List of config definitions to inherit from SourceConfig */
   private static final List<SourceConfigDefinition> SOURCE_CONFIG_DEFINITION_LIST =
       Arrays.asList(
@@ -45,6 +49,20 @@ public class TaskConfigDefinition {
         "",
         ConfigDef.Importance.HIGH,
         "Client ID used to uniquely identify the consumer in this task");
+    configDef.define(
+        REPLAY_POLICY,
+        ConfigDef.Type.STRING,
+        ReplayPolicy.IGNORE.toString(),
+        ConfigDef.Importance.LOW,
+        "Policy for handling bursts of duplicate records caused by offset resets."
+            + " Allowed values: IGNORE, FILTER");
+    configDef.define(
+        REPLAY_WINDOW_RECORDS,
+        ConfigDef.Type.LONG,
+        50000,
+        ConfigDef.Importance.LOW,
+        "Maximum duplicate records allowed per partition when an offset " + "reset is detected");
+
     return configDef;
   }
 }

--- a/src/main/java/com/salesforce/mirus/config/TaskConfigDefinition.java
+++ b/src/main/java/com/salesforce/mirus/config/TaskConfigDefinition.java
@@ -52,7 +52,7 @@ public class TaskConfigDefinition {
     configDef.define(
         REPLAY_POLICY,
         ConfigDef.Type.STRING,
-        ReplayPolicy.IGNORE.toString(),
+        ReplayPolicy.FILTER.toString(),
         ConfigDef.Importance.LOW,
         "Policy for handling bursts of duplicate records caused by offset resets. Allowed values: IGNORE, FILTER.");
     configDef.define(

--- a/src/main/java/com/salesforce/mirus/config/TaskConfigDefinition.java
+++ b/src/main/java/com/salesforce/mirus/config/TaskConfigDefinition.java
@@ -42,26 +42,25 @@ public class TaskConfigDefinition {
         ConfigDef.Type.STRING,
         "",
         ConfigDef.Importance.HIGH,
-        "The list of partitions for this task to handle");
+        "The list of partitions for this task to handle.");
     configDef.define(
         CONSUMER_CLIENT_ID,
         ConfigDef.Type.STRING,
         "",
         ConfigDef.Importance.HIGH,
-        "Client ID used to uniquely identify the consumer in this task");
+        "Client ID used to uniquely identify the consumer in this task.");
     configDef.define(
         REPLAY_POLICY,
         ConfigDef.Type.STRING,
         ReplayPolicy.IGNORE.toString(),
         ConfigDef.Importance.LOW,
-        "Policy for handling bursts of duplicate records caused by offset resets."
-            + " Allowed values: IGNORE, FILTER");
+        "Policy for handling bursts of duplicate records caused by offset resets. Allowed values: IGNORE, FILTER.");
     configDef.define(
         REPLAY_WINDOW_RECORDS,
         ConfigDef.Type.LONG,
         50000,
         ConfigDef.Importance.LOW,
-        "Maximum duplicate records allowed per partition when an offset " + "reset is detected");
+        "Maximum duplicate records allowed per partition when an offset reset is detected.");
 
     return configDef;
   }


### PR DESCRIPTION
This works around the KIP-320 bug (in Kafka <2.3.0), where the current consumer offset can become invalid after partition leadership changes, causing the consumer to reset to the start of the partition and duplicate records to be consumed. In this change we filter out duplicates before they reach the producer. 

Note that this change does not need to be applied to master as it uses Kafka 2.3.1.