### PR TITLE
Initialize the latest offset map

### DIFF
--- a/src/main/java/com/salesforce/mirus/MirusSourceTask.java
+++ b/src/main/java/com/salesforce/mirus/MirusSourceTask.java
@@ -170,6 +170,9 @@ public class MirusSourceTask extends SourceTask {
           } else {
             consumer.seek(tp, (Long) offsetMap.get(KEY_OFFSET));
           }
+          if (replayPolicy == ReplayPolicy.FILTER) {
+            latestOffsetMap.put(tp, consumer.position(tp)-1);
+          }
         });
   }
 


### PR DESCRIPTION
This PR probably does not need to be committed, is just here to cover us if there are edge cases where the log truncation bug  unexpected triggers a rebalance somehow. Better not to initialize like this as we generally prefer duplication over losing data.