### PR TITLE
Backport handling data replay

### DIFF
--- a/src/main/java/com/salesforce/mirus/MirusSourceTask.java
+++ b/src/main/java/com/salesforce/mirus/MirusSourceTask.java
@@ -8,8 +8,6 @@
 
 package com.salesforce.mirus;
 
-import com.salesforce.mirus.config.TaskConfig;
-import com.salesforce.mirus.config.TaskConfig.ReplayPolicy;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -18,6 +16,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
+
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
@@ -33,6 +32,9 @@ import org.apache.kafka.connect.storage.Converter;
 import org.apache.kafka.connect.storage.HeaderConverter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.salesforce.mirus.config.TaskConfig;
+import com.salesforce.mirus.config.TaskConfig.ReplayPolicy;
 
 interface ConsumerFactory {
   Consumer<byte[], byte[]> newConsumer(Map<String, Object> consumerProperties);
@@ -198,7 +200,7 @@ public class MirusSourceTask extends SourceTask {
     List<SourceRecord> sourceRecords = new ArrayList<>(pollResult.count());
     pollResult.forEach(
         consumerRecord -> {
-          if (!isSkippedRecord(consumerRecord)) {
+          if (replayPolicy == ReplayPolicy.FILTER && !isSkippedRecord(consumerRecord)) {
             sourceRecords.add(toSourceRecord(consumerRecord));
           }
         });

--- a/src/main/java/com/salesforce/mirus/MirusSourceTask.java
+++ b/src/main/java/com/salesforce/mirus/MirusSourceTask.java
@@ -9,9 +9,11 @@
 package com.salesforce.mirus;
 
 import com.salesforce.mirus.config.TaskConfig;
+import com.salesforce.mirus.config.TaskConfig.ReplayPolicy;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -49,7 +51,7 @@ public class MirusSourceTask extends SourceTask {
 
   private static final Logger logger = LoggerFactory.getLogger(MirusSourceTask.class);
 
-  private static final String KEY_OFFSET = "offset";
+  static final String KEY_OFFSET = "offset";
 
   private final ConsumerFactory consumerFactory;
 
@@ -63,6 +65,10 @@ public class MirusSourceTask extends SourceTask {
   private Converter keyConverter;
   private Converter valueConverter;
   private HeaderConverter headerConverter;
+  private ReplayPolicy replayPolicy;
+  private long replayWindowRecords;
+
+  private final Map<TopicPartition, Long> latestOffsetMap = new HashMap<>();
 
   protected AtomicBoolean shutDown = new AtomicBoolean(false);
 
@@ -102,6 +108,8 @@ public class MirusSourceTask extends SourceTask {
     this.keyConverter = config.getKeyConverter();
     this.valueConverter = config.getValueConverter();
     this.headerConverter = config.getHeaderConverter();
+    this.replayPolicy = config.getReplayPolicy();
+    this.replayWindowRecords = config.getReplayWindowRecords();
 
     logger.debug("Task starting with partitions: {}", config.getInternalTaskPartitions());
 
@@ -188,8 +196,29 @@ public class MirusSourceTask extends SourceTask {
 
   List<SourceRecord> sourceRecords(ConsumerRecords<byte[], byte[]> pollResult) {
     List<SourceRecord> sourceRecords = new ArrayList<>(pollResult.count());
-    pollResult.forEach(sourceRecord -> sourceRecords.add(toSourceRecord(sourceRecord)));
+    pollResult.forEach(
+        consumerRecord -> {
+          if (!isSkippedRecord(consumerRecord)) {
+            sourceRecords.add(toSourceRecord(consumerRecord));
+          }
+        });
     return sourceRecords;
+  }
+
+  private boolean isSkippedRecord(ConsumerRecord<byte[], byte[]> consumerRecord) {
+    if (replayPolicy == ReplayPolicy.FILTER) {
+      TopicPartition topicPartition =
+          new TopicPartition(consumerRecord.topic(), consumerRecord.partition());
+      long sourceOffset = consumerRecord.offset();
+      Long latestOffset = latestOffsetMap.get(topicPartition);
+      // Skip any record that has already been handled by this task
+      if (latestOffset != null && sourceOffset <= (latestOffset - replayWindowRecords)) {
+        return true;
+      } else {
+        latestOffsetMap.put(topicPartition, sourceOffset);
+      }
+    }
+    return false;
   }
 
   private SourceRecord toSourceRecord(ConsumerRecord<byte[], byte[]> consumerRecord) {

--- a/src/main/java/com/salesforce/mirus/config/TaskConfig.java
+++ b/src/main/java/com/salesforce/mirus/config/TaskConfig.java
@@ -8,7 +8,9 @@
 
 package com.salesforce.mirus.config;
 
-import java.util.*;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
 import org.apache.kafka.connect.storage.Converter;
 import org.apache.kafka.connect.storage.ConverterType;
 import org.apache.kafka.connect.storage.HeaderConverter;
@@ -20,6 +22,11 @@ import org.apache.kafka.connect.transforms.util.SimpleConfig;
  * {@link com.salesforce.mirus.MirusSourceTask} instances.
  */
 public class TaskConfig {
+
+  public enum ReplayPolicy {
+    IGNORE,
+    FILTER // Attempt to filter out duplicate records using the replay window
+  }
 
   private final SimpleConfig simpleConfig;
 
@@ -70,6 +77,14 @@ public class TaskConfig {
 
   public boolean getEnablePartitionMatching() {
     return simpleConfig.getBoolean(SourceConfigDefinition.ENABLE_PARTITION_MATCHING.key);
+  }
+
+  public ReplayPolicy getReplayPolicy() {
+    return ReplayPolicy.valueOf(simpleConfig.getString(TaskConfigDefinition.REPLAY_POLICY));
+  }
+
+  public long getReplayWindowRecords() {
+    return simpleConfig.getLong(TaskConfigDefinition.REPLAY_WINDOW_RECORDS);
   }
 
   public Converter getKeyConverter() {

--- a/src/main/java/com/salesforce/mirus/config/TaskConfigDefinition.java
+++ b/src/main/java/com/salesforce/mirus/config/TaskConfigDefinition.java
@@ -8,6 +8,7 @@
 
 package com.salesforce.mirus.config;
 
+import com.salesforce.mirus.config.TaskConfig.ReplayPolicy;
 import java.util.Arrays;
 import java.util.List;
 import org.apache.kafka.common.config.ConfigDef;
@@ -16,6 +17,9 @@ public class TaskConfigDefinition {
 
   public static final String PARTITION_LIST = "partitions";
   public static final String CONSUMER_CLIENT_ID = "consumer.client.id";
+  public static final String REPLAY_POLICY = "replay.policy";
+  public static final String REPLAY_WINDOW_RECORDS = "replay.window.records";
+
   /** List of config definitions to inherit from SourceConfig */
   private static final List<SourceConfigDefinition> SOURCE_CONFIG_DEFINITION_LIST =
       Arrays.asList(
@@ -38,13 +42,26 @@ public class TaskConfigDefinition {
         ConfigDef.Type.STRING,
         "",
         ConfigDef.Importance.HIGH,
-        "The list of partitions for this task to handle");
+        "The list of partitions for this task to handle.");
     configDef.define(
         CONSUMER_CLIENT_ID,
         ConfigDef.Type.STRING,
         "",
         ConfigDef.Importance.HIGH,
-        "Client ID used to uniquely identify the consumer in this task");
+        "Client ID used to uniquely identify the consumer in this task.");
+    configDef.define(
+        REPLAY_POLICY,
+        ConfigDef.Type.STRING,
+        ReplayPolicy.FILTER.toString(),
+        ConfigDef.Importance.LOW,
+        "Policy for handling bursts of duplicate records caused by offset resets. Allowed values: IGNORE, FILTER.");
+    configDef.define(
+        REPLAY_WINDOW_RECORDS,
+        ConfigDef.Type.LONG,
+        50000,
+        ConfigDef.Importance.LOW,
+        "Maximum duplicate records allowed per partition when an offset reset is detected.");
+
     return configDef;
   }
 }

--- a/src/main/java/com/salesforce/mirus/config/TaskConfigDefinition.java
+++ b/src/main/java/com/salesforce/mirus/config/TaskConfigDefinition.java
@@ -8,10 +8,12 @@
 
 package com.salesforce.mirus.config;
 
-import com.salesforce.mirus.config.TaskConfig.ReplayPolicy;
 import java.util.Arrays;
 import java.util.List;
+
 import org.apache.kafka.common.config.ConfigDef;
+
+import com.salesforce.mirus.config.TaskConfig.ReplayPolicy;
 
 public class TaskConfigDefinition {
 
@@ -52,7 +54,7 @@ public class TaskConfigDefinition {
     configDef.define(
         REPLAY_POLICY,
         ConfigDef.Type.STRING,
-        ReplayPolicy.FILTER.toString(),
+        ReplayPolicy.IGNORE.toString(),
         ConfigDef.Importance.LOW,
         "Policy for handling bursts of duplicate records caused by offset resets. Allowed values: IGNORE, FILTER.");
     configDef.define(

--- a/src/test/java/com/salesforce/mirus/MirusSourceTaskTest.java
+++ b/src/test/java/com/salesforce/mirus/MirusSourceTaskTest.java
@@ -8,11 +8,14 @@
 
 package com.salesforce.mirus;
 
-import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
 
 import com.salesforce.mirus.config.SourceConfigDefinition;
+import com.salesforce.mirus.config.TaskConfig.ReplayPolicy;
 import com.salesforce.mirus.config.TaskConfigDefinition;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -95,6 +98,8 @@ public class MirusSourceTaskTest {
     topicPartitionList.add(new TopicPartition(TOPIC, 1));
     properties.put(
         TaskConfigDefinition.PARTITION_LIST, TopicPartitionSerDe.toJson(topicPartitionList));
+    properties.put(TaskConfigDefinition.REPLAY_POLICY, ReplayPolicy.FILTER.toString());
+    properties.put(TaskConfigDefinition.REPLAY_WINDOW_RECORDS, "0");
     return properties;
   }
 
@@ -264,5 +269,90 @@ public class MirusSourceTaskTest {
     assertThat(sourceRecord.keySchema().type(), is(Schema.Type.STRUCT));
     assertThat(sourceRecord.valueSchema().type(), is(Schema.Type.STRUCT));
     assertThat(sourceRecord.timestamp(), is(-1L)); // Since the source record has no timestamp
+  }
+
+  @Test
+  public void testReplayFilterOnePartition() {
+
+    mockConsumer.updateBeginningOffsets(Collections.singletonMap(new TopicPartition(TOPIC, 0), 0L));
+
+    mockConsumer.addRecord(new ConsumerRecord<>(TOPIC, 0, 0, new byte[] {}, new byte[] {}));
+    mockConsumer.addRecord(new ConsumerRecord<>(TOPIC, 0, 1, new byte[] {}, new byte[] {}));
+    mockConsumer.addRecord(new ConsumerRecord<>(TOPIC, 0, 2, new byte[] {}, new byte[] {}));
+    List<SourceRecord> result = mirusSourceTask.poll();
+    assertThat(result.size(), is(3));
+
+    // Simulate an offset reset
+    mockConsumer.seekToBeginning(Collections.singletonList(new TopicPartition(TOPIC, 0)));
+
+    mockConsumer.addRecord(new ConsumerRecord<>(TOPIC, 0, 0, new byte[] {}, new byte[] {}));
+    mockConsumer.addRecord(new ConsumerRecord<>(TOPIC, 0, 1, new byte[] {}, new byte[] {}));
+    mockConsumer.addRecord(new ConsumerRecord<>(TOPIC, 0, 2, new byte[] {}, new byte[] {}));
+    mockConsumer.addRecord(new ConsumerRecord<>(TOPIC, 0, 3, new byte[] {}, new byte[] {}));
+    result = mirusSourceTask.poll();
+
+    assertThat(result.size(), is(1));
+    assertThat(result.get(0).sourceOffset().get(MirusSourceTask.KEY_OFFSET), is(4L));
+  }
+
+  @Test
+  public void testReplayFilterTwoPartitions() {
+
+    Map<TopicPartition, Long> initialOffsets = new HashMap<>();
+    initialOffsets.put(new TopicPartition(TOPIC, 0), 0L);
+    initialOffsets.put(new TopicPartition(TOPIC, 1), 0L);
+
+    mockConsumer.updateBeginningOffsets(initialOffsets);
+
+    mockConsumer.addRecord(new ConsumerRecord<>(TOPIC, 0, 0, new byte[] {}, new byte[] {}));
+    mockConsumer.addRecord(new ConsumerRecord<>(TOPIC, 0, 1, new byte[] {}, new byte[] {}));
+    mockConsumer.addRecord(new ConsumerRecord<>(TOPIC, 0, 2, new byte[] {}, new byte[] {}));
+    mockConsumer.addRecord(new ConsumerRecord<>(TOPIC, 1, 0, new byte[] {}, new byte[] {}));
+    mockConsumer.addRecord(new ConsumerRecord<>(TOPIC, 1, 1, new byte[] {}, new byte[] {}));
+    mockConsumer.addRecord(new ConsumerRecord<>(TOPIC, 1, 2, new byte[] {}, new byte[] {}));
+    List<SourceRecord> result = mirusSourceTask.poll();
+    assertThat(result.size(), is(6));
+
+    // Simulate an offset reset on ONE partition
+    mockConsumer.seekToBeginning(Collections.singletonList(new TopicPartition(TOPIC, 0)));
+
+    mockConsumer.addRecord(new ConsumerRecord<>(TOPIC, 0, 0, new byte[] {}, new byte[] {}));
+    mockConsumer.addRecord(new ConsumerRecord<>(TOPIC, 0, 1, new byte[] {}, new byte[] {}));
+    mockConsumer.addRecord(new ConsumerRecord<>(TOPIC, 0, 2, new byte[] {}, new byte[] {}));
+    mockConsumer.addRecord(new ConsumerRecord<>(TOPIC, 0, 3, new byte[] {}, new byte[] {}));
+    mockConsumer.addRecord(new ConsumerRecord<>(TOPIC, 1, 3, new byte[] {}, new byte[] {}));
+    result = mirusSourceTask.poll();
+
+    assertThat(result.size(), is(2));
+    assertThat(result.get(0).sourceOffset().get(MirusSourceTask.KEY_OFFSET), is(4L));
+    assertThat(result.get(1).sourceOffset().get(MirusSourceTask.KEY_OFFSET), is(4L));
+  }
+
+  @Test
+  public void testReplayFilterWindow() {
+
+    Map<String, String> properties = mockTaskProperties();
+    properties.put(TaskConfigDefinition.REPLAY_WINDOW_RECORDS, "2");
+    mirusSourceTask.start(properties);
+
+    mockConsumer.updateBeginningOffsets(Collections.singletonMap(new TopicPartition(TOPIC, 0), 0L));
+
+    mockConsumer.addRecord(new ConsumerRecord<>(TOPIC, 0, 0, new byte[] {}, new byte[] {}));
+    mockConsumer.addRecord(new ConsumerRecord<>(TOPIC, 0, 1, new byte[] {}, new byte[] {}));
+    mockConsumer.addRecord(new ConsumerRecord<>(TOPIC, 0, 2, new byte[] {}, new byte[] {}));
+    List<SourceRecord> result = mirusSourceTask.poll();
+    assertThat(result.size(), is(3));
+
+    // Simulate an offset reset
+    mockConsumer.seekToBeginning(Collections.singletonList(new TopicPartition(TOPIC, 0)));
+
+    mockConsumer.addRecord(new ConsumerRecord<>(TOPIC, 0, 0, new byte[] {}, new byte[] {}));
+    mockConsumer.addRecord(new ConsumerRecord<>(TOPIC, 0, 1, new byte[] {}, new byte[] {}));
+    mockConsumer.addRecord(new ConsumerRecord<>(TOPIC, 0, 2, new byte[] {}, new byte[] {}));
+    mockConsumer.addRecord(new ConsumerRecord<>(TOPIC, 0, 3, new byte[] {}, new byte[] {}));
+    result = mirusSourceTask.poll();
+
+    assertThat(result.size(), is(3));
+    assertThat(result.get(0).sourceOffset().get(MirusSourceTask.KEY_OFFSET), is(2L));
   }
 }


### PR DESCRIPTION
Back-port changes related to handling data replays in brach 0.2.x into the main branch. Make default behaviour of handling duplicates is IGNORE. 