### PR TITLE
Reset metrics when connector/task failed

### DIFF
--- a/src/main/java/com/salesforce/mirus/HerderStatusMonitor.java
+++ b/src/main/java/com/salesforce/mirus/HerderStatusMonitor.java
@@ -110,7 +110,7 @@ public class HerderStatusMonitor implements Runnable {
           if (connectorState == ConnectorStatus.State.RUNNING) {
             // All workers need to process all assigned tasks for the current connector
             connectorInfo.tasks().forEach(task -> processTask(task, herder.taskStatus(task)));
-          } else if (connectorState == ConnectorStatus.State.FAILED) {
+          } else {
             connectorJmxReport.closeConnector(connectorName);
           }
         });

--- a/src/main/java/com/salesforce/mirus/HerderStatusMonitor.java
+++ b/src/main/java/com/salesforce/mirus/HerderStatusMonitor.java
@@ -110,6 +110,8 @@ public class HerderStatusMonitor implements Runnable {
           if (connectorState == ConnectorStatus.State.RUNNING) {
             // All workers need to process all assigned tasks for the current connector
             connectorInfo.tasks().forEach(task -> processTask(task, herder.taskStatus(task)));
+          } else if (connectorState == ConnectorStatus.State.FAILED) {
+            connectorJmxReport.closeConnector(connectorName);
           }
         });
 
@@ -136,6 +138,7 @@ public class HerderStatusMonitor implements Runnable {
       TaskStatus.State taskState = TaskStatus.State.valueOf(taskStatus.state());
       if (taskState == TaskStatus.State.FAILED) {
         connectorJmxReport.incrementTotalFailedCount(taskId.connector());
+        taskJmxReporter.closeTask(taskId);
         if (autoRestartTaskEnabled) {
           logger.info("Attempting to restart task {}", taskId);
           herder.restartTask(taskId, this::onTaskRestart);

--- a/src/main/java/com/salesforce/mirus/metrics/ConnectorJmxReporter.java
+++ b/src/main/java/com/salesforce/mirus/metrics/ConnectorJmxReporter.java
@@ -132,6 +132,7 @@ public class ConnectorJmxReporter extends AbstractMirusJmxReporter {
             connectorLevelJmxTags,
             connectorTags);
 
+    // Won't reset this metric when connector restart
     MetricName restartAttemptsPerConnectorMetric =
         getMetric(
             FAILED_CONNECTOR_ATTEMPTS_METRIC_NAME + "-count",
@@ -147,8 +148,7 @@ public class ConnectorJmxReporter extends AbstractMirusJmxReporter {
             failedMetric,
             unassignedMetric,
             destroyedMetric,
-            totalAttemptsPerConnectorMetric,
-            restartAttemptsPerConnectorMetric);
+            totalAttemptsPerConnectorMetric);
     connectorMetrics.put(connectorName, metricsSet);
 
     Set<String> sensorSet = new HashSet<>();
@@ -187,7 +187,8 @@ public class ConnectorJmxReporter extends AbstractMirusJmxReporter {
     if (!metrics.metrics().containsKey(restartAttemptsPerConnectorMetric)) {
       String sensorName = FAILED_CONNECTOR_ATTEMPTS_METRIC_NAME + connectorName;
       metrics.sensor(sensorName).add(restartAttemptsPerConnectorMetric, new Total());
-      sensorSet.add(sensorName);
+
+      // Won't reset this metric when connector restart
     }
 
     connectorSensors.put(connectorName, sensorSet);
@@ -196,14 +197,11 @@ public class ConnectorJmxReporter extends AbstractMirusJmxReporter {
   public void incrementTotalFailedCount(String connector) {
     String sensorName = FAILED_TASK_ATTEMPTS_METRIC_NAME + connector;
     metrics.sensor(sensorName).record(1, Time.SYSTEM.milliseconds());
-
-    connectorSensors.get(connector).add(sensorName);
   }
 
   public void incrementConnectorRestartAttempts(String connector) {
     String sensorName = FAILED_CONNECTOR_ATTEMPTS_METRIC_NAME + connector;
     metrics.sensor(sensorName).record(1, Time.SYSTEM.milliseconds());
-    // Won't clear this metrics after connector restart
   }
 
   public synchronized void closeConnector(String connector) {

--- a/src/main/java/com/salesforce/mirus/metrics/ConnectorJmxReporter.java
+++ b/src/main/java/com/salesforce/mirus/metrics/ConnectorJmxReporter.java
@@ -8,6 +8,7 @@
 
 package com.salesforce.mirus.metrics;
 
+import com.google.common.collect.Sets;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -16,8 +17,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-
-import com.google.common.collect.Sets;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.metrics.stats.Total;
@@ -141,59 +140,53 @@ public class ConnectorJmxReporter extends AbstractMirusJmxReporter {
             connectorLevelJmxTags,
             connectorTags);
 
-    Set<MetricName> metricsSet = Sets.newHashSet(runningMetric, pausedMetric, failedMetric, unassignedMetric, destroyedMetric, totalAttemptsPerConnectorMetric, restartAttemptsPerConnectorMetric);
+    Set<MetricName> metricsSet =
+        Sets.newHashSet(
+            runningMetric,
+            pausedMetric,
+            failedMetric,
+            unassignedMetric,
+            destroyedMetric,
+            totalAttemptsPerConnectorMetric,
+            restartAttemptsPerConnectorMetric);
     connectorMetrics.put(connectorName, metricsSet);
 
     Set<String> sensorSet = new HashSet<>();
     if (!metrics.metrics().containsKey(runningMetric)) {
       String sensorName = calculateSensorName(allStates.get("RUNNING"), connectorName);
-      metrics
-          .sensor(sensorName)
-          .add(runningMetric, new Value());
+      metrics.sensor(sensorName).add(runningMetric, new Value());
       sensorSet.add(sensorName);
     }
     if (!metrics.metrics().containsKey(pausedMetric)) {
       String sensorName = calculateSensorName(allStates.get("PAUSED"), connectorName);
-      metrics
-          .sensor(sensorName)
-          .add(pausedMetric, new Value());
+      metrics.sensor(sensorName).add(pausedMetric, new Value());
       sensorSet.add(sensorName);
     }
 
     if (!metrics.metrics().containsKey(failedMetric)) {
       String sensorName = calculateSensorName(allStates.get("FAILED"), connectorName);
-      metrics
-          .sensor(sensorName)
-          .add(failedMetric, new Value());
+      metrics.sensor(sensorName).add(failedMetric, new Value());
       sensorSet.add(sensorName);
     }
     if (!metrics.metrics().containsKey(unassignedMetric)) {
       String sensorName = calculateSensorName(allStates.get("UNASSIGNED"), connectorName);
-      metrics
-          .sensor(sensorName)
-          .add(unassignedMetric, new Value());
+      metrics.sensor(sensorName).add(unassignedMetric, new Value());
       sensorSet.add(sensorName);
     }
     if (!metrics.metrics().containsKey(destroyedMetric)) {
       String sensorName = calculateSensorName(allStates.get("DESTROYED"), connectorName);
-      metrics
-          .sensor(sensorName)
-          .add(destroyedMetric, new Value());
+      metrics.sensor(sensorName).add(destroyedMetric, new Value());
       sensorSet.add(sensorName);
     }
     if (!metrics.metrics().containsKey(totalAttemptsPerConnectorMetric)) {
       String sensorName = FAILED_TASK_ATTEMPTS_METRIC_NAME + connectorName;
-      metrics
-          .sensor(sensorName)
-          .add(totalAttemptsPerConnectorMetric, new Total());
+      metrics.sensor(sensorName).add(totalAttemptsPerConnectorMetric, new Total());
       sensorSet.add(sensorName);
     }
 
     if (!metrics.metrics().containsKey(restartAttemptsPerConnectorMetric)) {
       String sensorName = FAILED_CONNECTOR_ATTEMPTS_METRIC_NAME + connectorName;
-      metrics
-          .sensor(sensorName)
-          .add(restartAttemptsPerConnectorMetric, new Total());
+      metrics.sensor(sensorName).add(restartAttemptsPerConnectorMetric, new Total());
       sensorSet.add(sensorName);
     }
 
@@ -202,18 +195,14 @@ public class ConnectorJmxReporter extends AbstractMirusJmxReporter {
 
   public void incrementTotalFailedCount(String connector) {
     String sensorName = FAILED_TASK_ATTEMPTS_METRIC_NAME + connector;
-    metrics
-        .sensor(sensorName)
-        .record(1, Time.SYSTEM.milliseconds());
+    metrics.sensor(sensorName).record(1, Time.SYSTEM.milliseconds());
 
     connectorSensors.get(connector).add(sensorName);
   }
 
   public void incrementConnectorRestartAttempts(String connector) {
     String sensorName = FAILED_CONNECTOR_ATTEMPTS_METRIC_NAME + connector;
-    metrics
-        .sensor(sensorName)
-        .record(1, Time.SYSTEM.milliseconds());
+    metrics.sensor(sensorName).record(1, Time.SYSTEM.milliseconds());
     // Won't clear this metrics after connector restart
   }
 

--- a/src/test/java/com/salesforce/mirus/metrics/ConnectorJmxReporterTest.java
+++ b/src/test/java/com/salesforce/mirus/metrics/ConnectorJmxReporterTest.java
@@ -86,23 +86,23 @@ public class ConnectorJmxReporterTest {
   @Test
   public void testMetricsClearAfterConnectorClosed() {
     assertEquals(
-            0.0d,
-            metrics
-                    .metric(new MetricName("task-failed-restart-attempts-count", GROUP, "", tags))
-                    .metricValue());
+        0.0d,
+        metrics
+            .metric(new MetricName("task-failed-restart-attempts-count", GROUP, "", tags))
+            .metricValue());
     connectorJmxReporter.incrementTotalFailedCount(CONNECTOR_NAME);
     assertEquals(
-            1.0d,
-            metrics
-                    .metric(new MetricName("task-failed-restart-attempts-count", GROUP, "", tags))
-                    .metricValue());
+        1.0d,
+        metrics
+            .metric(new MetricName("task-failed-restart-attempts-count", GROUP, "", tags))
+            .metricValue());
 
     connectorJmxReporter.closeConnector(CONNECTOR_NAME);
     connectorJmxReporter.handleConnector(herder, connectorInfo);
     assertEquals(
-            0.0d,
-            metrics
-                    .metric(new MetricName("task-failed-restart-attempts-count", GROUP, "", tags))
-                    .metricValue());
+        0.0d,
+        metrics
+            .metric(new MetricName("task-failed-restart-attempts-count", GROUP, "", tags))
+            .metricValue());
   }
 }

--- a/src/test/java/com/salesforce/mirus/metrics/ConnectorJmxReporterTest.java
+++ b/src/test/java/com/salesforce/mirus/metrics/ConnectorJmxReporterTest.java
@@ -82,4 +82,27 @@ public class ConnectorJmxReporterTest {
             .metric(new MetricName("connector-failed-restart-attempts-count", GROUP, "", tags))
             .metricValue());
   }
+
+  @Test
+  public void testMetricsClearAfterConnectorClosed() {
+    assertEquals(
+            0.0d,
+            metrics
+                    .metric(new MetricName("task-failed-restart-attempts-count", GROUP, "", tags))
+                    .metricValue());
+    connectorJmxReporter.incrementTotalFailedCount(CONNECTOR_NAME);
+    assertEquals(
+            1.0d,
+            metrics
+                    .metric(new MetricName("task-failed-restart-attempts-count", GROUP, "", tags))
+                    .metricValue());
+
+    connectorJmxReporter.closeConnector(CONNECTOR_NAME);
+    connectorJmxReporter.handleConnector(herder, connectorInfo);
+    assertEquals(
+            0.0d,
+            metrics
+                    .metric(new MetricName("task-failed-restart-attempts-count", GROUP, "", tags))
+                    .metricValue());
+  }
 }


### PR DESCRIPTION
Reset metrics when connector/task failed, this is to prevent Worker reporting the last task state metrics which could be obsolete. 

A better place to reset metrics is in connector/task's `stop` method, but in our code Herder will manage metrics reporting, so have to do it in `HerderStatusMonitor`