### PR TITLE
Provide ability to override kafka-monitor destination configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ another topic in the same cluster. To avoid a conflict the destination topic nam
                "tasks.max": "5",
                "topics.whitelist": "test",
                "destination.topic.name.suffix": ".mirror",
-               "destination.bootstrap.servers": "localhost:9092",
+               "destination.consumer.bootstrap.servers": "localhost:9092",
                "consumer.bootstrap.servers": "localhost:9092",
                "consumer.client.id": "mirus-quickstart",
                "consumer.key.deserializer": "org.apache.kafka.common.serialization.ByteArrayDeserializer",

--- a/README.md
+++ b/README.md
@@ -192,7 +192,9 @@ These can be added to the JSON config object posted to the REST API `/config` en
 new MirusSourceConnector instance. In addition, the Kafka Consumer instances
 created by Mirus Tasks can be configured using a `consumer.` prefix on the standard
 [Kafka Consumer properties](https://kafka.apache.org/documentation/#consumerconfigs). The equivalent
-KafkaProducer options are configured in the Mirus Worker Properties file (see below).
+KafkaProducer options are configured in the Mirus Worker Properties file (see below). The
+  `destination.consumer.`prefix can be used to override the properties of the KafkaConsumer that connects to
+   the destination Kafka cluster.
 
 - [Mirus Worker Properties](src/main/java/com/salesforce/mirus/config/MirusConfigDefinition.java)
 These are Mirus extensions to the Kafka Connect configuration, and should be applied to the
@@ -203,7 +205,7 @@ can also be configured using a `producer.` prefix on the standard
 ## Destination Topic Checking
 
 By default, Mirus checks that the destination topic exists in the destination Kafka cluster before
-stating to replicate data to it. This feature can be disabled by setting the
+starting to replicate data to it. This feature can be disabled by setting the
 [enable.destination.topic.checking](src/main/java/com/salesforce/mirus/config/SourceConfigDefinition.java#L66)
 config option to `false`.
 

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>4.13.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/com/salesforce/mirus/KafkaMonitor.java
+++ b/src/main/java/com/salesforce/mirus/KafkaMonitor.java
@@ -153,8 +153,29 @@ class KafkaMonitor implements Runnable {
     return new KafkaConsumer<>(consumerProperties);
   }
 
+  /**
+   * * Reconciles the default consumer properties with the destination-consumer properties. The
+   * destination-consumer properties have higher precedence.
+   *
+   * @param config config of the source connector
+   * @return map that includes the consumer configs
+   */
+  static Map<String, Object> getReconciledDestConsumerConfigs(SourceConfig config) {
+    // handle destination.bootstrap.server separately
+    // keeping this config for backward compatibility
+    String destBootstrap = config.getDestinationBootstrapServers();
+    Map<String, Object> destConsumerProps = config.getDestinationConsumerProperties();
+
+    destConsumerProps.computeIfAbsent(
+        "bootstrap.servers", s -> destConsumerProps.put("bootstrap.servers", destBootstrap));
+    Map<String, Object> reconciledConsumerConfigs = config.getConsumerProperties();
+    // use destination.consumer properties to override default consumer properties
+    destConsumerProps.forEach((k, v) -> reconciledConsumerConfigs.put(k, v));
+    return reconciledConsumerConfigs;
+  }
+
   private static Consumer<byte[], byte[]> newDestinationConsumer(SourceConfig config) {
-    Map<String, Object> consumerProperties = config.getDestinationConsumerConfigs();
+    Map<String, Object> consumerProperties = getReconciledDestConsumerConfigs(config);
     // The "monitor2" client id suffix is used to keep JMX bean names distinct
     consumerProperties.computeIfPresent(
         CommonClientConfigs.CLIENT_ID_CONFIG, (k, v) -> v + "monitor2");

--- a/src/main/java/com/salesforce/mirus/KafkaMonitor.java
+++ b/src/main/java/com/salesforce/mirus/KafkaMonitor.java
@@ -21,7 +21,6 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.consumer.Consumer;
-import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.RetriableException;
@@ -155,13 +154,10 @@ class KafkaMonitor implements Runnable {
   }
 
   private static Consumer<byte[], byte[]> newDestinationConsumer(SourceConfig config) {
-    Map<String, Object> consumerProperties = config.getConsumerProperties();
-
+    Map<String, Object> consumerProperties = config.getDestinationConsumerConfigs();
     // The "monitor2" client id suffix is used to keep JMX bean names distinct
     consumerProperties.computeIfPresent(
         CommonClientConfigs.CLIENT_ID_CONFIG, (k, v) -> v + "monitor2");
-    consumerProperties.put(
-        ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, config.getDestinationBootstrapServers());
     return new KafkaConsumer<>(consumerProperties);
   }
 

--- a/src/main/java/com/salesforce/mirus/MirusSourceTask.java
+++ b/src/main/java/com/salesforce/mirus/MirusSourceTask.java
@@ -8,6 +8,8 @@
 
 package com.salesforce.mirus;
 
+import com.salesforce.mirus.config.TaskConfig;
+import com.salesforce.mirus.config.TaskConfig.ReplayPolicy;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -33,9 +35,6 @@ import org.apache.kafka.connect.storage.Converter;
 import org.apache.kafka.connect.storage.HeaderConverter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.salesforce.mirus.config.TaskConfig;
-import com.salesforce.mirus.config.TaskConfig.ReplayPolicy;
 
 interface ConsumerFactory {
   Consumer<byte[], byte[]> newConsumer(Map<String, Object> consumerProperties);
@@ -210,7 +209,8 @@ public class MirusSourceTask extends SourceTask {
   }
 
   private boolean isSkippedRecord(ConsumerRecord<byte[], byte[]> consumerRecord) {
-    TopicPartition topicPartition = new TopicPartition(consumerRecord.topic(), consumerRecord.partition());
+    TopicPartition topicPartition =
+        new TopicPartition(consumerRecord.topic(), consumerRecord.partition());
     long sourceOffset = consumerRecord.offset();
     Long latestOffset = latestOffsetMap.get(topicPartition);
     // Skip any record that has already been handled by this task
@@ -223,14 +223,17 @@ public class MirusSourceTask extends SourceTask {
     return false;
   }
 
-  private void maybeLogSkippedRecord(TopicPartition topicPartition, long sourceOffset, long latestOffset) {
-    if(!loggingFlags.contains(topicPartition)) {
-      logger.info("Skipping record with topic-partition={}, offset={}. Latest previously recorded offset={}. "
-                      + "This log statement is recorded once per task instance per topic-partition.",
-              topicPartition, sourceOffset, latestOffset);
+  private void maybeLogSkippedRecord(
+      TopicPartition topicPartition, long sourceOffset, long latestOffset) {
+    if (!loggingFlags.contains(topicPartition)) {
+      logger.info(
+          "Skipping record with topic-partition={}, offset={}. Latest previously recorded offset={}. "
+              + "This log statement is recorded once per task instance per topic-partition.",
+          topicPartition,
+          sourceOffset,
+          latestOffset);
       loggingFlags.add(topicPartition);
     }
-
   }
 
   private SourceRecord toSourceRecord(ConsumerRecord<byte[], byte[]> consumerRecord) {

--- a/src/main/java/com/salesforce/mirus/MirusSourceTask.java
+++ b/src/main/java/com/salesforce/mirus/MirusSourceTask.java
@@ -8,8 +8,6 @@
 
 package com.salesforce.mirus;
 
-import com.salesforce.mirus.config.TaskConfig;
-import com.salesforce.mirus.config.TaskConfig.ReplayPolicy;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -35,6 +33,9 @@ import org.apache.kafka.connect.storage.Converter;
 import org.apache.kafka.connect.storage.HeaderConverter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.salesforce.mirus.config.TaskConfig;
+import com.salesforce.mirus.config.TaskConfig.ReplayPolicy;
 
 interface ConsumerFactory {
   Consumer<byte[], byte[]> newConsumer(Map<String, Object> consumerProperties);
@@ -209,8 +210,7 @@ public class MirusSourceTask extends SourceTask {
   }
 
   private boolean isSkippedRecord(ConsumerRecord<byte[], byte[]> consumerRecord) {
-    TopicPartition topicPartition =
-        new TopicPartition(consumerRecord.topic(), consumerRecord.partition());
+    TopicPartition topicPartition = new TopicPartition(consumerRecord.topic(), consumerRecord.partition());
     long sourceOffset = consumerRecord.offset();
     Long latestOffset = latestOffsetMap.get(topicPartition);
     // Skip any record that has already been handled by this task
@@ -223,17 +223,14 @@ public class MirusSourceTask extends SourceTask {
     return false;
   }
 
-  private void maybeLogSkippedRecord(
-      TopicPartition topicPartition, long sourceOffset, long latestOffset) {
-    if (!loggingFlags.contains(topicPartition)) {
-      logger.info(
-          "Skipping record with topic-partition={}, offset={}. Latest previously recorded offset={}. "
-              + "This log statement is recorded once per task instance per topic-partition.",
-          topicPartition,
-          sourceOffset,
-          latestOffset);
+  private void maybeLogSkippedRecord(TopicPartition topicPartition, long sourceOffset, long latestOffset) {
+    if(!loggingFlags.contains(topicPartition)) {
+      logger.info("Skipping record with topic-partition={}, offset={}. Latest previously recorded offset={}. "
+                      + "This log statement is recorded once per task instance per topic-partition.",
+              topicPartition, sourceOffset, latestOffset);
       loggingFlags.add(topicPartition);
     }
+
   }
 
   private SourceRecord toSourceRecord(ConsumerRecord<byte[], byte[]> consumerRecord) {

--- a/src/main/java/com/salesforce/mirus/MirusSourceTask.java
+++ b/src/main/java/com/salesforce/mirus/MirusSourceTask.java
@@ -8,6 +8,8 @@
 
 package com.salesforce.mirus;
 
+import com.salesforce.mirus.config.TaskConfig;
+import com.salesforce.mirus.config.TaskConfig.ReplayPolicy;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -18,7 +20,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
-
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
@@ -34,9 +35,6 @@ import org.apache.kafka.connect.storage.Converter;
 import org.apache.kafka.connect.storage.HeaderConverter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.salesforce.mirus.config.TaskConfig;
-import com.salesforce.mirus.config.TaskConfig.ReplayPolicy;
 
 interface ConsumerFactory {
   Consumer<byte[], byte[]> newConsumer(Map<String, Object> consumerProperties);
@@ -211,7 +209,8 @@ public class MirusSourceTask extends SourceTask {
   }
 
   private boolean isSkippedRecord(ConsumerRecord<byte[], byte[]> consumerRecord) {
-    TopicPartition topicPartition = new TopicPartition(consumerRecord.topic(), consumerRecord.partition());
+    TopicPartition topicPartition =
+        new TopicPartition(consumerRecord.topic(), consumerRecord.partition());
     long sourceOffset = consumerRecord.offset();
     Long latestOffset = latestOffsetMap.get(topicPartition);
     // Skip any record that has already been handled by this task
@@ -224,14 +223,17 @@ public class MirusSourceTask extends SourceTask {
     return false;
   }
 
-  private void maybeLogSkippedRecord(TopicPartition topicPartition, long sourceOffset, long latestOffset) {
-    if(!loggingFlags.contains(topicPartition)) {
-      logger.info("Skipping record with topic-partition={}, offset={}. Latest previously recorded offset={}. "
-        + "This log statement is recorded once per task instance per topic-partition.",
-        topicPartition, sourceOffset, latestOffset);
+  private void maybeLogSkippedRecord(
+      TopicPartition topicPartition, long sourceOffset, long latestOffset) {
+    if (!loggingFlags.contains(topicPartition)) {
+      logger.info(
+          "Skipping record with topic-partition={}, offset={}. Latest previously recorded offset={}. "
+              + "This log statement is recorded once per task instance per topic-partition.",
+          topicPartition,
+          sourceOffset,
+          latestOffset);
       loggingFlags.add(topicPartition);
     }
-
   }
 
   private SourceRecord toSourceRecord(ConsumerRecord<byte[], byte[]> consumerRecord) {

--- a/src/main/java/com/salesforce/mirus/config/SourceConfig.java
+++ b/src/main/java/com/salesforce/mirus/config/SourceConfig.java
@@ -12,6 +12,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.protocol.types.Field;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.runtime.ConnectorConfig;
 import org.apache.kafka.connect.source.SourceRecord;
@@ -44,7 +45,14 @@ public class SourceConfig {
   }
 
   private Map<String, Object> getDestinationProperties() {
-    return simpleConfig.originalsWithPrefix("destination.");
+    // handle destination.bootstrap.server separately
+    String destBootstrap =
+        simpleConfig.getString(SourceConfigDefinition.DESTINATION_BOOTSTRAP_SERVERS.key);
+    Map<String, Object> destConsumerProps =
+        simpleConfig.originalsWithPrefix("destination.consumer.");
+    destConsumerProps.computeIfAbsent(
+        "bootstrap.servers", s -> destConsumerProps.put("bootstrap.servers", destBootstrap));
+    return destConsumerProps;
   }
 
   public Map<String, Object> getDestinationConsumerConfigs() {

--- a/src/main/java/com/salesforce/mirus/config/SourceConfig.java
+++ b/src/main/java/com/salesforce/mirus/config/SourceConfig.java
@@ -43,8 +43,17 @@ public class SourceConfig {
     return simpleConfig.originalsWithPrefix("consumer.");
   }
 
-  public String getDestinationBootstrapServers() {
-    return simpleConfig.getString(SourceConfigDefinition.DESTINATION_BOOTSTRAP_SERVERS.key);
+  private Map<String, Object> getDestinationProperties() {
+    return simpleConfig.originalsWithPrefix("destination.");
+  }
+
+  public Map<String, Object> getDestinationConsumerConfigs() {
+    Map<String, Object> reconciledConsumerProperties = getConsumerProperties();
+    Map<String, Object> destinationProperties = getDestinationProperties();
+    // override consumer properties with any KafkaMonitor-specific property
+    destinationProperties.forEach((k, v) -> reconciledConsumerProperties.put(k, v));
+
+    return reconciledConsumerProperties;
   }
 
   public boolean getEnablePartitionMatching() {

--- a/src/main/java/com/salesforce/mirus/config/SourceConfig.java
+++ b/src/main/java/com/salesforce/mirus/config/SourceConfig.java
@@ -49,9 +49,8 @@ public class SourceConfig {
 
   public Map<String, Object> getDestinationConsumerConfigs() {
     Map<String, Object> reconciledConsumerProperties = getConsumerProperties();
-    Map<String, Object> destinationProperties = getDestinationProperties();
     // override consumer properties with any KafkaMonitor-specific property
-    destinationProperties.forEach((k, v) -> reconciledConsumerProperties.put(k, v));
+    getDestinationProperties().forEach((k, v) -> reconciledConsumerProperties.put(k, v));
 
     return reconciledConsumerProperties;
   }

--- a/src/main/java/com/salesforce/mirus/config/SourceConfig.java
+++ b/src/main/java/com/salesforce/mirus/config/SourceConfig.java
@@ -12,7 +12,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import org.apache.kafka.common.config.ConfigDef;
-import org.apache.kafka.common.protocol.types.Field;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.runtime.ConnectorConfig;
 import org.apache.kafka.connect.source.SourceRecord;
@@ -44,23 +43,13 @@ public class SourceConfig {
     return simpleConfig.originalsWithPrefix("consumer.");
   }
 
-  private Map<String, Object> getDestinationProperties() {
-    // handle destination.bootstrap.server separately
-    String destBootstrap =
-        simpleConfig.getString(SourceConfigDefinition.DESTINATION_BOOTSTRAP_SERVERS.key);
-    Map<String, Object> destConsumerProps =
-        simpleConfig.originalsWithPrefix("destination.consumer.");
-    destConsumerProps.computeIfAbsent(
-        "bootstrap.servers", s -> destConsumerProps.put("bootstrap.servers", destBootstrap));
-    return destConsumerProps;
+  public Map<String, Object> getDestinationConsumerProperties() {
+    return simpleConfig.originalsWithPrefix("destination.consumer.");
   }
 
-  public Map<String, Object> getDestinationConsumerConfigs() {
-    Map<String, Object> reconciledConsumerProperties = getConsumerProperties();
-    // override consumer properties with any KafkaMonitor-specific property
-    getDestinationProperties().forEach((k, v) -> reconciledConsumerProperties.put(k, v));
-
-    return reconciledConsumerProperties;
+  @Deprecated
+  public String getDestinationBootstrapServers() {
+    return simpleConfig.getString(SourceConfigDefinition.DESTINATION_BOOTSTRAP_SERVERS.key);
   }
 
   public boolean getEnablePartitionMatching() {

--- a/src/main/java/com/salesforce/mirus/config/SourceConfigDefinition.java
+++ b/src/main/java/com/salesforce/mirus/config/SourceConfigDefinition.java
@@ -89,7 +89,13 @@ public enum SourceConfigDefinition {
       ConfigDef.Type.CLASS,
       "org.apache.kafka.connect.converters.ByteArrayConverter",
       ConfigDef.Importance.MEDIUM,
-      "Converter class to apply to source record headers");
+      "Converter class to apply to source record headers"),
+  DESTINATION_BOOTSTRAP_SERVERS(
+          "destination.bootstrap.servers",
+          ConfigDef.Type.STRING,
+          "",
+          ConfigDef.Importance.HIGH,
+          "Comma-separated list of destination bootstrap server endpoints in standard format. This is used by the Kafka Monitor for run-time topic validation");
 
   String key;
   ConfigDef.Type type;

--- a/src/main/java/com/salesforce/mirus/config/SourceConfigDefinition.java
+++ b/src/main/java/com/salesforce/mirus/config/SourceConfigDefinition.java
@@ -90,12 +90,13 @@ public enum SourceConfigDefinition {
       "org.apache.kafka.connect.converters.ByteArrayConverter",
       ConfigDef.Importance.MEDIUM,
       "Converter class to apply to source record headers"),
+  @Deprecated
   DESTINATION_BOOTSTRAP_SERVERS(
-          "destination.bootstrap.servers",
-          ConfigDef.Type.STRING,
-          "",
-          ConfigDef.Importance.HIGH,
-          "Comma-separated list of destination bootstrap server endpoints in standard format. This is used by the Kafka Monitor for run-time topic validation");
+      "destination.bootstrap.servers",
+      ConfigDef.Type.STRING,
+      "",
+      ConfigDef.Importance.HIGH,
+      "Comma-separated list of destination bootstrap server endpoints in standard format. This is used by the Kafka Monitor for run-time topic validation");
 
   String key;
   ConfigDef.Type type;

--- a/src/main/java/com/salesforce/mirus/config/SourceConfigDefinition.java
+++ b/src/main/java/com/salesforce/mirus/config/SourceConfigDefinition.java
@@ -89,13 +89,7 @@ public enum SourceConfigDefinition {
       ConfigDef.Type.CLASS,
       "org.apache.kafka.connect.converters.ByteArrayConverter",
       ConfigDef.Importance.MEDIUM,
-      "Converter class to apply to source record headers"),
-  DESTINATION_BOOTSTRAP_SERVERS(
-      "destination.bootstrap.servers",
-      ConfigDef.Type.STRING,
-      "",
-      ConfigDef.Importance.HIGH,
-      "Comma-separated list of destination bootstrap server endpoints in standard format. This is used by the Kafka Monitor for run-time topic validation");
+      "Converter class to apply to source record headers");
 
   String key;
   ConfigDef.Type type;

--- a/src/main/java/com/salesforce/mirus/config/TaskConfigDefinition.java
+++ b/src/main/java/com/salesforce/mirus/config/TaskConfigDefinition.java
@@ -8,12 +8,10 @@
 
 package com.salesforce.mirus.config;
 
+import com.salesforce.mirus.config.TaskConfig.ReplayPolicy;
 import java.util.Arrays;
 import java.util.List;
-
 import org.apache.kafka.common.config.ConfigDef;
-
-import com.salesforce.mirus.config.TaskConfig.ReplayPolicy;
 
 public class TaskConfigDefinition {
 

--- a/src/main/java/com/salesforce/mirus/config/TaskConfigDefinition.java
+++ b/src/main/java/com/salesforce/mirus/config/TaskConfigDefinition.java
@@ -8,10 +8,12 @@
 
 package com.salesforce.mirus.config;
 
-import com.salesforce.mirus.config.TaskConfig.ReplayPolicy;
 import java.util.Arrays;
 import java.util.List;
+
 import org.apache.kafka.common.config.ConfigDef;
+
+import com.salesforce.mirus.config.TaskConfig.ReplayPolicy;
 
 public class TaskConfigDefinition {
 

--- a/src/test/java/com/salesforce/mirus/config/SourceConfigTest.java
+++ b/src/test/java/com/salesforce/mirus/config/SourceConfigTest.java
@@ -78,10 +78,10 @@ public class SourceConfigTest {
     properties.put("topics", "abc,def");
     properties.put("source.bootstrap.servers", "localhost:123");
     properties.put("destination.bootstrap.servers", "remotehost1:123,remotehost2:123");
-    properties.put("destination.b", "11,22,33");
-    properties.put("destination.ssl.http.proxy.address", "");
+    properties.put("destination.consumer.b", "11,22,33");
+    properties.put("destination.consumer.ssl.http.proxy.address", "");
     properties.put("source.consumer.poll.timeout.ms", "1000");
-    properties.put("destination.topic.name.suffix", "suffix");
+    properties.put("destination.consumer.topic.name.suffix", "suffix");
     properties.put("extra.key", "suffix");
     properties.put("consumer.a", "1");
     properties.put("consumer.b", "1,2,3");
@@ -89,7 +89,26 @@ public class SourceConfigTest {
   }
 
   @Test
-  public void destinationPropertiesShouldOverrideDefaultConsumerProps() {
+  public void destinationBootstrapPrecedenceIsRight(){
+    Map<String, String> properties = new HashMap<>();
+    properties.put("name", "testConnector");
+    properties.put("destination.bootstrap.servers", "bad1:123,bad2:123");
+    properties.put("destination.consumer.bootstrap.servers", "good1:123,good2:123");
+    properties.put("consumer.a", "1");
+    properties.put("destination.consumer.a", "11");
+    properties.put("destination.consumer.b", "22");
+    mirusSourceConfig = new SourceConfig(properties);
+
+    Map<String, String> expectedDestConsumerProperties = new HashMap<>();
+    expectedDestConsumerProperties.put("bootstrap.servers", "good1:123,good2:123");
+    expectedDestConsumerProperties.put("a", "11");
+    expectedDestConsumerProperties.put("b", "22");
+    assertThat(
+        mirusSourceConfig.getDestinationConsumerConfigs(), is(expectedDestConsumerProperties));
+  }
+
+  @Test
+  public void destinationConsumerPropertiesShouldOverrideDefaultConsumerProps() {
     Map<String, String> expectedConsumerProperties = new HashMap<>();
     expectedConsumerProperties.put("a", "1");
     expectedConsumerProperties.put("b", "1,2,3");

--- a/src/test/java/com/salesforce/mirus/config/SourceConfigTest.java
+++ b/src/test/java/com/salesforce/mirus/config/SourceConfigTest.java
@@ -78,50 +78,12 @@ public class SourceConfigTest {
     properties.put("topics", "abc,def");
     properties.put("source.bootstrap.servers", "localhost:123");
     properties.put("destination.bootstrap.servers", "remotehost1:123,remotehost2:123");
-    properties.put("destination.consumer.b", "11,22,33");
-    properties.put("destination.consumer.ssl.http.proxy.address", "");
     properties.put("source.consumer.poll.timeout.ms", "1000");
-    properties.put("destination.consumer.topic.name.suffix", "suffix");
+    properties.put("destination.topic.name.suffix", "suffix");
     properties.put("extra.key", "suffix");
     properties.put("consumer.a", "1");
     properties.put("consumer.b", "1,2,3");
     mirusSourceConfig = new SourceConfig(properties);
-  }
-
-  @Test
-  public void destinationBootstrapPrecedenceIsRight(){
-    Map<String, String> properties = new HashMap<>();
-    properties.put("name", "testConnector");
-    properties.put("destination.bootstrap.servers", "bad1:123,bad2:123");
-    properties.put("destination.consumer.bootstrap.servers", "good1:123,good2:123");
-    properties.put("consumer.a", "1");
-    properties.put("destination.consumer.a", "11");
-    properties.put("destination.consumer.b", "22");
-    mirusSourceConfig = new SourceConfig(properties);
-
-    Map<String, String> expectedDestConsumerProperties = new HashMap<>();
-    expectedDestConsumerProperties.put("bootstrap.servers", "good1:123,good2:123");
-    expectedDestConsumerProperties.put("a", "11");
-    expectedDestConsumerProperties.put("b", "22");
-    assertThat(
-        mirusSourceConfig.getDestinationConsumerConfigs(), is(expectedDestConsumerProperties));
-  }
-
-  @Test
-  public void destinationConsumerPropertiesShouldOverrideDefaultConsumerProps() {
-    Map<String, String> expectedConsumerProperties = new HashMap<>();
-    expectedConsumerProperties.put("a", "1");
-    expectedConsumerProperties.put("b", "1,2,3");
-    assertThat(mirusSourceConfig.getConsumerProperties(), is(expectedConsumerProperties));
-
-    Map<String, String> expectedDestConsumerProperties = new HashMap<>();
-    expectedDestConsumerProperties.put("bootstrap.servers", "remotehost1:123,remotehost2:123");
-    expectedDestConsumerProperties.put("ssl.http.proxy.address", "");
-    expectedDestConsumerProperties.put("b", "11,22,33");
-    expectedDestConsumerProperties.put("a", "1");
-    expectedDestConsumerProperties.put("topic.name.suffix", "suffix");
-    assertThat(
-        mirusSourceConfig.getDestinationConsumerConfigs(), is(expectedDestConsumerProperties));
   }
 
   @Test
@@ -133,19 +95,14 @@ public class SourceConfigTest {
   }
 
   @Test
-  public void consumerDestinationPropertiesShouldIncludeBothDefaultAndDestinationProps() {
-    Map<String, String> expectedProperties = new HashMap<>();
-    expectedProperties.put("bootstrap.servers", "remotehost1:123,remotehost2:123");
-    expectedProperties.put("ssl.http.proxy.address", "");
-    expectedProperties.put("topic.name.suffix", "suffix");
-    expectedProperties.put("a", "1");
-    expectedProperties.put("b", "11,22,33");
-    assertThat(mirusSourceConfig.getDestinationConsumerConfigs(), is(expectedProperties));
+  public void defaultValuesShouldBeApplied() {
+    assertThat(mirusSourceConfig.getTopicsRegex(), is(""));
   }
 
   @Test
-  public void defaultValuesShouldBeApplied() {
-    assertThat(mirusSourceConfig.getTopicsRegex(), is(""));
+  public void destinationBootstrapShouldBeAvailable() {
+    assertThat(
+        mirusSourceConfig.getDestinationBootstrapServers(), is("remotehost1:123,remotehost2:123"));
   }
 
   @Test

--- a/src/test/java/com/salesforce/mirus/config/SourceConfigTest.java
+++ b/src/test/java/com/salesforce/mirus/config/SourceConfigTest.java
@@ -78,12 +78,31 @@ public class SourceConfigTest {
     properties.put("topics", "abc,def");
     properties.put("source.bootstrap.servers", "localhost:123");
     properties.put("destination.bootstrap.servers", "remotehost1:123,remotehost2:123");
+    properties.put("destination.b", "11,22,33");
+    properties.put("destination.ssl.http.proxy.address", "");
     properties.put("source.consumer.poll.timeout.ms", "1000");
     properties.put("destination.topic.name.suffix", "suffix");
     properties.put("extra.key", "suffix");
     properties.put("consumer.a", "1");
     properties.put("consumer.b", "1,2,3");
     mirusSourceConfig = new SourceConfig(properties);
+  }
+
+  @Test
+  public void destinationPropertiesShouldOverrideDefaultConsumerProps() {
+    Map<String, String> expectedConsumerProperties = new HashMap<>();
+    expectedConsumerProperties.put("a", "1");
+    expectedConsumerProperties.put("b", "1,2,3");
+    assertThat(mirusSourceConfig.getConsumerProperties(), is(expectedConsumerProperties));
+
+    Map<String, String> expectedDestConsumerProperties = new HashMap<>();
+    expectedDestConsumerProperties.put("bootstrap.servers", "remotehost1:123,remotehost2:123");
+    expectedDestConsumerProperties.put("ssl.http.proxy.address", "");
+    expectedDestConsumerProperties.put("b", "11,22,33");
+    expectedDestConsumerProperties.put("a", "1");
+    expectedDestConsumerProperties.put("topic.name.suffix", "suffix");
+    assertThat(
+        mirusSourceConfig.getDestinationConsumerConfigs(), is(expectedDestConsumerProperties));
   }
 
   @Test
@@ -95,14 +114,19 @@ public class SourceConfigTest {
   }
 
   @Test
-  public void defaultValuesShouldBeApplied() {
-    assertThat(mirusSourceConfig.getTopicsRegex(), is(""));
+  public void consumerDestinationPropertiesShouldIncludeBothDefaultAndDestinationProps() {
+    Map<String, String> expectedProperties = new HashMap<>();
+    expectedProperties.put("bootstrap.servers", "remotehost1:123,remotehost2:123");
+    expectedProperties.put("ssl.http.proxy.address", "");
+    expectedProperties.put("topic.name.suffix", "suffix");
+    expectedProperties.put("a", "1");
+    expectedProperties.put("b", "11,22,33");
+    assertThat(mirusSourceConfig.getDestinationConsumerConfigs(), is(expectedProperties));
   }
 
   @Test
-  public void destinationBootstrapShouldBeAvailable() {
-    assertThat(
-        mirusSourceConfig.getDestinationBootstrapServers(), is("remotehost1:123,remotehost2:123"));
+  public void defaultValuesShouldBeApplied() {
+    assertThat(mirusSourceConfig.getTopicsRegex(), is(""));
   }
 
   @Test


### PR DESCRIPTION
The main change here is treating the configs with prefix `destination.` as an override to the `consumer.` configs. This means that the connection to the _destination_ cluster's configs will be the combination of the default consumer configs with any override set using the prefix `destination.`.