### PR TITLE
Upgrade Mirus to Kafka Connect 2.6.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.salesforce.mirus</groupId>
     <artifactId>mirus</artifactId>
-    <version>0.4.2-SNAPSHOT</version>
+    <version>0.5.0-SNAPSHOT</version>
 
     <name>Mirus</name>
     <description>Apache Kafka data replication tool based on Kafka Connect</description>
@@ -13,7 +13,7 @@
         <dist.dir>${project.build.directory}/dist</dist.dir>
         <jackson.version>2.10.0</jackson.version>
         <java.numeric.version>1.8</java.numeric.version>
-        <kafka.version>2.3.1</kafka.version>
+        <kafka.version>2.6.1</kafka.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -27,6 +27,11 @@
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-csv</artifactId>
             <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>30.1-jre</version>
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,9 @@
             <artifactId>jackson-dataformat-csv</artifactId>
             <version>${jackson.version}</version>
         </dependency>
+        <!-- Guava is added in the 2.6.1 build of Mirus since the Google libraries were removed
+             in upstream Kafka Connect. This dependency can be removed with further refactoring
+             within Mirus. --> 
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>

--- a/src/main/java/com/salesforce/mirus/Mirus.java
+++ b/src/main/java/com/salesforce/mirus/Mirus.java
@@ -135,6 +135,9 @@ public class Mirus {
    * support, to prevent JMX metric names from clashing. Also supports command-line property
    * overrides (useful for run-time port configuration), and starts the Mirus {@link
    * HerderStatusMonitor}.
+   *
+   * @param workerProps Worker Properties as a map.
+   * @return Connect object.
    */
   public Connect startConnect(Map<String, String> workerProps) {
     log.info("Scanning for plugin classes. This might take a moment ...");


### PR DESCRIPTION
* Updates Mirus to 2.6.1

* Adds additional test to OffsetSetterTest for testing more cases.
* Adds schema configuration to JsonConverter in OffsetSetterTest due to changes in 2.4.0
* Adds comments to suppress Javadoc warnings