### PR TITLE
Switch to using ssh based authentication to GitHub

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -340,8 +340,8 @@
     </developers>
 
     <scm>
-        <connection>scm:git:https://github.com/salesforce/mirus.git</connection>
-        <developerConnection>scm:git:https://github.com/salesforce/mirus.git</developerConnection>
+        <connection>scm:git:ssh://git@github.com/salesforce/mirus.git</connection>
+        <developerConnection>scm:git:ssh://git@github.com/salesforce/mirus.git</developerConnection>
         <url>http://github.com/salesforce/mirus</url>
         <tag>HEAD</tag>
     </scm>


### PR DESCRIPTION
The current method of using application keys is an additional step to upload
using ssh keys avoids the need to generate application keys.