### PR TITLE
Add Latency Reporting to Mirus

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,9 +214,49 @@ As of version 0.2.0, destination topic checking can also support topic re-routin
 No other `Router` Transformations are supported, so destination topic checking must be disabled in order
 to use them.
 
+## Metrics
+
+Mirus produces some custom metrics in addition to the standard Kafka Connect metrics.
+
+JMX Queries are as follows
+
+### Latency (MirrorJmxReporter)
+
+```
+objectName="mirus:type=MirusSourceConnector,topic=*" attribute="replication-latency-ms-max"
+objectName="mirus:type=MirusSourceConnector,topic=*" attribute="replication-latency-ms-min"
+objectName="mirus:type=MirusSourceConnector,topic=*" attribute="replication-latency-ms-avg"
+objectName="mirus:type=MirusSourceConnector,topic=*" attribute="replication-latency-ms-count"
+```
+
+### Destination Information (MissingPartitionsJmxReporter)
+
+```
+objectName="mirus:type=mirus" attribute="missing-dest-partitions-count"
+```
+
+### Connector Metrics (ConnectorJmxReporter)
+
+```
+objectName="mirus:type=connector-metrics,connector=*" attribute="task-failed-restart-attempts-count"
+objectName="mirus:type=connector-metrics,connector=*" attribute="connector-failed-restart-attempts-count"
+objectName="mirus:type=connector-metrics,connector=*" attribute="failed-task-count"
+objectName="mirus:type=connector-metrics,connector=*" attribute="paused-task-count"
+objectName="mirus:type=connector-metrics,connector=*" attribute="destroyed-task-count"
+objectName="mirus:type=connector-metrics,connector=*" attribute="running-task-count"
+objectName="mirus:type=connector-metrics,connector=*" attribute="unassigned-task-count"
+```
+
+### Task Metrics (TaskJmxReporter)
+
+```
+objectName="mirus:type=connector-task-metrics,connector=*" attribute="task-failed-restart-attempts-count"
+```
+
 ## Developer Info
 
 To preform a release: `mvn release:prepare release:perform`
+GPG Keys may need to be passed to maven with `-Darguments='-Dgpg.passphrase= -Dgpg.keyname=55Z32RD1'`
 
 # Discussion
 

--- a/src/main/java/com/salesforce/mirus/MirusSourceTask.java
+++ b/src/main/java/com/salesforce/mirus/MirusSourceTask.java
@@ -236,12 +236,8 @@ public class MirusSourceTask extends SourceTask {
       //
       // record.kafkaPartition() is null when 1:1 partition mapping is not enabled.
       //
-      try {
-        long latency = System.currentTimeMillis() - metadata.timestamp();
-        mirrorJmxReporter.recordMirrorLatency(record.topic(), latency);
-      } catch (Exception exception){
-        logger.error(exception.getMessage(), exception);
-      }
+      long latency = System.currentTimeMillis() - metadata.timestamp();
+      mirrorJmxReporter.recordMirrorLatency(record.topic(), latency);
   }
 
   private void checkCommitFailure() {

--- a/src/main/java/com/salesforce/mirus/metrics/AbstractMirusJmxReporter.java
+++ b/src/main/java/com/salesforce/mirus/metrics/AbstractMirusJmxReporter.java
@@ -15,7 +15,7 @@ import org.apache.kafka.common.MetricNameTemplate;
 import org.apache.kafka.common.metrics.JmxReporter;
 import org.apache.kafka.common.metrics.Metrics;
 
-abstract class AbstractMirusJmxReporter {
+abstract class AbstractMirusJmxReporter implements AutoCloseable {
 
   static final String CONNECTOR_KEY = "connector";
   static final String TASK_KEY = "task";
@@ -33,4 +33,9 @@ abstract class AbstractMirusJmxReporter {
 
     return metrics.metricInstance(failedTaskCountTemplate, runtimeTags);
   }
+
+  @Override
+  public void close() {
+        metrics.close();
+    }
 }

--- a/src/main/java/com/salesforce/mirus/metrics/MirrorJmxReporter.java
+++ b/src/main/java/com/salesforce/mirus/metrics/MirrorJmxReporter.java
@@ -1,0 +1,134 @@
+package com.salesforce.mirus.metrics;
+
+import com.salesforce.mirus.MirusSourceConnector;
+import org.apache.kafka.common.MetricNameTemplate;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.metrics.Sensor;
+import org.apache.kafka.common.metrics.stats.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class MirrorJmxReporter extends AbstractMirusJmxReporter {
+
+    private static final Logger logger = LoggerFactory.getLogger(MirrorJmxReporter.class);
+
+    private static MirrorJmxReporter instance = null;
+
+    private static final String SOURCE_CONNECTOR_GROUP = MirusSourceConnector.class.getSimpleName();
+
+    private static final Set<String> TOPIC_TAGS = new HashSet<>(Collections.singletonList("topic"));
+
+    private static final MetricNameTemplate REPLICATION_LATENCY = new MetricNameTemplate(
+            "replication-latency-ms", SOURCE_CONNECTOR_GROUP,
+            "Time it takes records to replicate from source to target cluster.", TOPIC_TAGS);
+    private static final MetricNameTemplate REPLICATION_LATENCY_MAX = new MetricNameTemplate(
+            "replication-latency-ms-max", SOURCE_CONNECTOR_GROUP,
+            "Max time it takes records to replicate from source to target cluster.", TOPIC_TAGS);
+    private static final MetricNameTemplate REPLICATION_LATENCY_MIN = new MetricNameTemplate(
+            "replication-latency-ms-min", SOURCE_CONNECTOR_GROUP,
+            "Min time it takes records to replicate from source to target cluster.", TOPIC_TAGS);
+    private static final MetricNameTemplate REPLICATION_LATENCY_AVG = new MetricNameTemplate(
+            "replication-latency-ms-avg", SOURCE_CONNECTOR_GROUP,
+            "Average time it takes records to replicate from source to target cluster.", TOPIC_TAGS);
+
+    // Map of topics to their metric objects
+    private final Map<String, Sensor> topicSensors;
+    private final Set<TopicPartition> topicPartitionSet;
+
+    private MirrorJmxReporter() {
+        super(new Metrics());
+        metrics.sensor("replication-latency");
+
+        topicSensors = new HashMap<>();
+        topicPartitionSet = new HashSet<>();
+
+        logger.info("Initialized MirrorJMXReporter");
+    }
+    public synchronized static MirrorJmxReporter getInstance() {
+        if (null == instance) {
+            instance = new MirrorJmxReporter();
+        }
+        return instance;
+    }
+
+    /**
+     * Add a list of partitions to record the latency of.
+     * @param topicPartitions
+     */
+    public synchronized void addTopics(List<TopicPartition> topicPartitions) {
+        topicSensors.putAll(
+                topicPartitions
+                        .stream()
+                        .map(TopicPartition::topic)
+                        .distinct()
+                        .filter(topic -> !topicSensors.containsKey(topic))
+                        .collect(Collectors.toMap(topic -> topic, this::createTopicSensor))
+        );
+        topicPartitionSet.addAll(topicPartitions);
+    }
+
+    /**
+     * Remove a list of partitions from the metrics, this is involved since we want to record
+     * if a single partition of a topic is held by this worker.
+     * @param topicPartitions
+     */
+    public synchronized void removeTopics(List<TopicPartition> topicPartitions) {
+        // We want to remove all topics that are passed in topicPartitions
+        // However, we need to be smart since the topic may still be "owned" by a different partition.
+
+        topicPartitionSet.removeAll(topicPartitions);
+
+        // Get all the distinct topic names that should still exist in the sensors.
+        // Then subtract that set from topics to remove.
+        // We don't need calls to "distinct" since we are operating with sets of strings.
+        Set<String> currentTopics = topicPartitionSet
+                .stream()
+                .map(TopicPartition::topic)
+                .collect(Collectors.toSet());
+
+        Set<String> topicsToRemove = topicPartitions
+                .stream()
+                .map(TopicPartition::topic)
+                .filter(topic -> !currentTopics.contains(topic))
+                .collect(Collectors.toSet());
+
+
+        topicsToRemove.forEach(
+                topic -> {
+                    metrics.removeSensor(replicationLatencySensorName(topic));
+                    topicSensors.remove(topic);
+                }
+        );
+    }
+
+
+    public synchronized void recordMirrorLatency(String topic, long millis) {
+        Sensor sensor = topicSensors.get(topic);
+        if (sensor != null) {
+            sensor.record((double) millis);
+        }
+    }
+
+
+    private Sensor createTopicSensor(String topic) {
+
+
+        Map<String, String> tags = new LinkedHashMap<>();
+        tags.put("topic", topic);
+
+        Sensor sensor = metrics.sensor(replicationLatencySensorName(topic));
+        sensor.add(metrics.metricInstance(REPLICATION_LATENCY, tags), new Value());
+        sensor.add(metrics.metricInstance(REPLICATION_LATENCY_MAX, tags), new Max());
+        sensor.add(metrics.metricInstance(REPLICATION_LATENCY_MIN, tags), new Min());
+        sensor.add(metrics.metricInstance(REPLICATION_LATENCY_AVG, tags), new Avg());
+        return sensor;
+    }
+
+    private String replicationLatencySensorName(String topic) {
+        return topic + "-" + "replication-latency";
+    }
+}


### PR DESCRIPTION
## What does this commit do?
* Adds latency reporting on a per-topic basis to Mirus
* Makes all JMX Reporters AutoClosable