### PR TITLE
Use sourceRecord timestamp as reference for end-to-end latency

### DIFF
--- a/src/main/java/com/salesforce/mirus/MirusSourceTask.java
+++ b/src/main/java/com/salesforce/mirus/MirusSourceTask.java
@@ -121,9 +121,8 @@ public class MirusSourceTask extends SourceTask {
     this.replayPolicy = config.getReplayPolicy();
     this.replayWindowRecords = config.getReplayWindowRecords();
 
-    topicPartitionList = TopicPartitionSerDe.parseTopicPartitionList(
-            config.getInternalTaskPartitions()
-    );
+    topicPartitionList =
+        TopicPartitionSerDe.parseTopicPartitionList(config.getInternalTaskPartitions());
     this.mirrorJmxReporter = MirrorJmxReporter.getInstance();
     this.mirrorJmxReporter.addTopics(topicPartitionList);
 
@@ -225,16 +224,14 @@ public class MirusSourceTask extends SourceTask {
     successfulCommitTime = time.milliseconds();
   }
 
-  /**
-   * Callback that is called when a record is committed.
-   */
+  /** Callback that is called when a record is committed. */
   @Override
   public void commitRecord(SourceRecord sourceRecord, RecordMetadata metadata) {
-      //
-      // record.kafkaPartition() is null when 1:1 partition mapping is not enabled.
-      //
-      long latency = System.currentTimeMillis() - sourceRecord.timestamp();
-      mirrorJmxReporter.recordMirrorLatency(sourceRecord.topic(), latency);
+    //
+    // record.kafkaPartition() is null when 1:1 partition mapping is not enabled.
+    //
+    long latency = System.currentTimeMillis() - sourceRecord.timestamp();
+    mirrorJmxReporter.recordMirrorLatency(sourceRecord.topic(), latency);
   }
 
   private void checkCommitFailure() {

--- a/src/main/java/com/salesforce/mirus/MirusSourceTask.java
+++ b/src/main/java/com/salesforce/mirus/MirusSourceTask.java
@@ -10,17 +10,6 @@ package com.salesforce.mirus;
 
 import com.salesforce.mirus.config.TaskConfig;
 import com.salesforce.mirus.config.TaskConfig.ReplayPolicy;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.stream.Collectors;
-
 import com.salesforce.mirus.metrics.MirrorJmxReporter;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -40,6 +29,10 @@ import org.apache.kafka.connect.storage.Converter;
 import org.apache.kafka.connect.storage.HeaderConverter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.*;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
 
 interface ConsumerFactory {
   Consumer<byte[], byte[]> newConsumer(Map<String, Object> consumerProperties);
@@ -236,12 +229,12 @@ public class MirusSourceTask extends SourceTask {
    * Callback that is called when a record is committed.
    */
   @Override
-  public void commitRecord(SourceRecord record, RecordMetadata metadata) {
+  public void commitRecord(SourceRecord sourceRecord, RecordMetadata metadata) {
       //
       // record.kafkaPartition() is null when 1:1 partition mapping is not enabled.
       //
-      long latency = System.currentTimeMillis() - metadata.timestamp();
-      mirrorJmxReporter.recordMirrorLatency(record.topic(), latency);
+      long latency = System.currentTimeMillis() - sourceRecord.timestamp();
+      mirrorJmxReporter.recordMirrorLatency(sourceRecord.topic(), latency);
   }
 
   private void checkCommitFailure() {


### PR DESCRIPTION
The current latency is incorrect when the destination cluster is using `log.message.timestamp.type=LogAppendTime`. In this case the metadata timestamp will be initialized when the record is written to the target broker, so we don't see overall end-to-end latency. 